### PR TITLE
The boardctl for NuttX reset may not exist

### DIFF
--- a/libs4c/libshvtree/include/shv/tree/shv_connection.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_connection.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #include "shv_clayer_posix.h"
 

--- a/libs4c/libshvtree/shv_clayer_posix.c
+++ b/libs4c/libshvtree/shv_clayer_posix.c
@@ -38,6 +38,7 @@
     #include <sys/syscall.h>
     #include <time.h>
 #elif defined(CONFIG_SHV_LIBS4C_PLATFORM_NUTTX)
+    #include <nuttx/config.h>
     #include <nuttx/crc32.h>
     #include <sys/boardctl.h>
 #endif
@@ -196,7 +197,9 @@ int shv_dotdevice_node_posix_reset(void)
     //reboot(LINUX_REBOOT_CMD_RESTART); /* This is dangerous, commented */
 #endif
 #ifdef CONFIG_SHV_LIBS4C_PLATFORM_NUTTX
+#if defined(CONFIG_BOARDCTL_RESET) || defined(CONFIG_BOARDCTL_RESET_CAUSE)
     boardctl(BOARDIOC_RESET, BOARDIOC_RESETCAUSE_CPU_SOFT);
+#endif
 #endif
 }
 


### PR DESCRIPTION
This commit fixes this with checking the appropiate NuttX defines.

closes #15 