### PR TITLE
libshvtree: fix the priority of the thread and compile warning

### DIFF
--- a/libs4c/libshvtree/shv_com.c
+++ b/libs4c/libshvtree/shv_com.c
@@ -104,7 +104,6 @@ void shv_pack_head_request(shv_con_ctx_t *shv_ctx, char *met, char *path)
 int shv_unpack_head(shv_con_ctx_t * shv_ctx, int * rid, char * method,
                     char * path)
 {
-  int l;
   int i;
   bool ok;
 
@@ -115,7 +114,7 @@ int shv_unpack_head(shv_con_ctx_t * shv_ctx, int * rid, char * method,
 
   /* Unpack length */
 
-  l = cchainpack_unpack_uint_data(ctx, &ok);
+  cchainpack_unpack_uint_data(ctx, &ok);
 
   cchainpack_unpack_next(ctx);
   if (ctx->err_no != CCPCP_RC_OK) return -1;
@@ -1076,7 +1075,6 @@ static inline int shv_process_communication(shv_con_ctx_t *shv_ctx)
 int shv_process(shv_con_ctx_t *shv_ctx)
 {
     int ret;
-    const struct timespec ts = {shv_ctx->connection->reconnect_period, 0};
     /* A local enum to keep track of the connection */
     enum {NOT_INIT = 0, INIT_BUT_NO_CONN, CONN} conn_state = NOT_INIT;
 

--- a/libs4c/libshvtree/shv_file_node.c
+++ b/libs4c/libshvtree/shv_file_node.c
@@ -153,7 +153,6 @@ int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *ite
     int ret;
     ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
     item->platform_error = false;
-    struct shv_file_node_fctx *fctx = (struct shv_file_node_fctx *) item->fctx;
 
     do {
         cchainpack_unpack_next(ctx);
@@ -294,7 +293,6 @@ int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *ite
  */
 int shv_file_process_crc(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
 {
-    int ret;
     int parse_result = -1;
     size_t size;
     int start;


### PR DESCRIPTION
- pthread_attr was, infact, unused!
- many compile warning of unused variables, etc...