### PR TITLE
Detypdeftify libshvtree

### DIFF
--- a/libs4c/libshvtree/include/shv/tree/shv_clayer_posix.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_clayer_posix.h
@@ -20,8 +20,9 @@
 
 #define SHV_FILE_POSIX_BITFLAG_OPENED ((uint32_t)(1 << 0)) /* File already opened flag */
 
+/* Forward declarations */
 typedef struct shv_dotdevice_node shv_dotdevice_node_t;
-typedef struct shv_file_node shv_file_node_t;
+struct shv_file_node;
 struct shv_connection;
 
 struct shv_file_node_fctx
@@ -63,7 +64,7 @@ struct shv_thrd_ctx
  * @param item
  * @return int
  */
-int shv_file_node_posix_opener(shv_file_node_t *item);
+int shv_file_node_posix_opener(struct shv_file_node *item);
 
 /**
  * @brief POSIX shv_file_node_getsize implementation
@@ -71,7 +72,7 @@ int shv_file_node_posix_opener(shv_file_node_t *item);
  * @param item
  * @return int
  */
-int shv_file_node_posix_getsize(shv_file_node_t *item);
+int shv_file_node_posix_getsize(struct shv_file_node *item);
 
 /**
  * @brief POSIX shv_file_node_writer implementation
@@ -81,7 +82,7 @@ int shv_file_node_posix_getsize(shv_file_node_t *item);
  * @param count
  * @return int
  */
-int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count);
+int shv_file_node_posix_writer(struct shv_file_node *item, void *buf, size_t count);
 
 /**
  * @brief POSIX shv_file_node_seeker implementation
@@ -90,7 +91,7 @@ int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count);
  * @param offset
  * @return int
  */
-int shv_file_node_posix_seeker(shv_file_node_t *item, int offset);
+int shv_file_node_posix_seeker(struct shv_file_node *item, int offset);
 
 /**
  * @brief POSIX shv_file_node_reader implementation
@@ -100,7 +101,7 @@ int shv_file_node_posix_seeker(shv_file_node_t *item, int offset);
  * @param count
  * @return int
  */
-int shv_file_node_posix_reader(shv_file_node_t *item, void *buf, size_t count);
+int shv_file_node_posix_reader(struct shv_file_node *item, void *buf, size_t count);
 
 /**
  * @brief POSIX shv_file_node_crc32 implementation
@@ -111,7 +112,7 @@ int shv_file_node_posix_reader(shv_file_node_t *item, void *buf, size_t count);
  * @param result
  * @return int
  */
-int shv_file_node_posix_crc32(shv_file_node_t *item, int start, size_t size, uint32_t *result);
+int shv_file_node_posix_crc32(struct shv_file_node *item, int start, size_t size, uint32_t *result);
 
 /**
  * @brief POSIX shv_dotdevice_node_uptime implementation

--- a/libs4c/libshvtree/include/shv/tree/shv_clayer_posix.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_clayer_posix.h
@@ -21,7 +21,7 @@
 #define SHV_FILE_POSIX_BITFLAG_OPENED ((uint32_t)(1 << 0)) /* File already opened flag */
 
 /* Forward declarations */
-typedef struct shv_dotdevice_node shv_dotdevice_node_t;
+struct shv_dotdevice_node;
 struct shv_file_node;
 struct shv_connection;
 

--- a/libs4c/libshvtree/include/shv/tree/shv_com.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_com.h
@@ -140,10 +140,11 @@ struct shv_dir_res {
   int access;
 };
 
-typedef struct shv_str_list_it_t shv_str_list_it_t;
+/* Forward declaration */
+struct shv_str_list_it;
 
-struct shv_str_list_it_t {
-   const char * (*get_next_entry)(shv_str_list_it_t *it, int reset_to_first);
+struct shv_str_list_it {
+   const char * (*get_next_entry)(struct shv_str_list_it *it, int reset_to_first);
 };
 
 /**
@@ -162,7 +163,7 @@ void shv_send_uint(struct shv_con_ctx *shv_ctx, int rid, unsigned int num);
 void shv_send_double(struct shv_con_ctx *shv_ctx, int rid, double num);
 void shv_send_str(struct shv_con_ctx *shv_ctx, int rid, const char *str);
 void shv_send_str_list(struct shv_con_ctx *shv_ctx, int rid, int num_str, const char **str);
-void shv_send_str_list_it(struct shv_con_ctx *shv_ctx, int rid, int num_str, shv_str_list_it_t *str_it);
+void shv_send_str_list_it(struct shv_con_ctx *shv_ctx, int rid, int num_str, struct shv_str_list_it *str_it);
 void shv_send_dir(struct shv_con_ctx *shv_ctx, const struct shv_dir_res *results, int cnt, int rid);
 void shv_send_error(struct shv_con_ctx *shv_ctx, int rid, enum shv_response_error_code code,
                     const char *msg);

--- a/libs4c/libshvtree/include/shv/tree/shv_com.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_com.h
@@ -85,20 +85,20 @@ static const char *shv_con_errno_strs[SHV_ERRNOS_COUNT] =
 enum shv_attention_reason
 {
     SHV_ATTENTION_ERROR,        /* A nonrecoverable error occured, you should inspect
-                                   `err_no` in shv_con_ctx_t */
+                                   `err_no` in struct shv_con_ctx */
     SHV_ATTENTION_CONNECTED,    /* The thread succesfully connected to a broker */
     SHV_ATTENTION_DISCONNECTED, /* The connection was closed by the remote host */
     SHV_ATTENTION_COUNT
 };
 
 /* Forward declaration */
-typedef struct shv_con_ctx shv_con_ctx_t;
+struct shv_con_ctx;
 
 /**
  * @brief An attention signaller used to signal the application
  *        of some events
  */
-typedef void (*shv_attention_signaller)(shv_con_ctx_t *shv_ctx,
+typedef void (*shv_attention_signaller)(struct shv_con_ctx *shv_ctx,
                                         enum shv_attention_reason r);
 
 /* Forward declaration */
@@ -108,28 +108,29 @@ struct shv_node;
  * @brief Main SHV Communication context.
  *
  */
-typedef struct shv_con_ctx {
-  int stream_fd;
-  int timeout;
-  int rid;
-  int cid_cnt;
-  int cid_capacity;
-  int *cid_ptr;
-  enum shv_con_errno err_no;
-  struct ccpcp_pack_context pack_ctx;
-  struct ccpcp_unpack_context unpack_ctx;
-  char shv_data[SHV_BUF_LEN];
-  char shv_rd_data[SHV_BUF_LEN];
-  int write_err;
-  int shv_len;
-  int shv_send;
-  int reconnects;
-  atomic_bool running;
-  struct shv_thrd_ctx thrd_ctx;
-  struct shv_node *root;
-  struct shv_connection *connection;            /* Transport layer information */
-  shv_attention_signaller at_signlr;            /* A user defined attention signaller callback */
-} shv_con_ctx_t;
+struct shv_con_ctx
+{
+    int stream_fd;
+    int timeout;
+    int rid;
+    int cid_cnt;
+    int cid_capacity;
+    int *cid_ptr;
+    enum shv_con_errno err_no;
+    struct ccpcp_pack_context pack_ctx;
+    struct ccpcp_unpack_context unpack_ctx;
+    char shv_data[SHV_BUF_LEN];
+    char shv_rd_data[SHV_BUF_LEN];
+    int write_err;
+    int shv_len;
+    int shv_send;
+    int reconnects;
+    atomic_bool running;
+    struct shv_thrd_ctx thrd_ctx;
+    struct shv_node *root;
+    struct shv_connection *connection;            /* Transport layer information */
+    shv_attention_signaller at_signlr;            /* A user defined attention signaller callback */
+};
 
 struct shv_dir_res {
   const char *name;
@@ -151,22 +152,22 @@ struct shv_str_list_it_t {
  * @param ctx
  * @return const char*
  */
-static inline const char *shv_errno_str(shv_con_ctx_t *ctx)
+static inline const char *shv_errno_str(struct shv_con_ctx *ctx)
 {
     return shv_con_errno_strs[ctx->err_no];
 }
 
-void shv_send_int(shv_con_ctx_t *shv_ctx, int rid, int num);
-void shv_send_uint(shv_con_ctx_t *shv_ctx, int rid, unsigned int num);
-void shv_send_double(shv_con_ctx_t *shv_ctx, int rid, double num);
-void shv_send_str(shv_con_ctx_t *shv_ctx, int rid, const char *str);
-void shv_send_str_list(shv_con_ctx_t *shv_ctx, int rid, int num_str, const char **str);
-void shv_send_str_list_it(shv_con_ctx_t *shv_ctx, int rid, int num_str, shv_str_list_it_t *str_it);
-void shv_send_dir(shv_con_ctx_t *shv_ctx, const struct shv_dir_res *results, int cnt, int rid);
-void shv_send_error(shv_con_ctx_t *shv_ctx, int rid, enum shv_response_error_code code,
+void shv_send_int(struct shv_con_ctx *shv_ctx, int rid, int num);
+void shv_send_uint(struct shv_con_ctx *shv_ctx, int rid, unsigned int num);
+void shv_send_double(struct shv_con_ctx *shv_ctx, int rid, double num);
+void shv_send_str(struct shv_con_ctx *shv_ctx, int rid, const char *str);
+void shv_send_str_list(struct shv_con_ctx *shv_ctx, int rid, int num_str, const char **str);
+void shv_send_str_list_it(struct shv_con_ctx *shv_ctx, int rid, int num_str, shv_str_list_it_t *str_it);
+void shv_send_dir(struct shv_con_ctx *shv_ctx, const struct shv_dir_res *results, int cnt, int rid);
+void shv_send_error(struct shv_con_ctx *shv_ctx, int rid, enum shv_response_error_code code,
                     const char *msg);
-void shv_send_ping(shv_con_ctx_t *shv_ctx);
-void shv_send_empty_response(shv_con_ctx_t *shv_ctx, int rid);
+void shv_send_ping(struct shv_con_ctx *shv_ctx);
+void shv_send_empty_response(struct shv_con_ctx *shv_ctx, int rid);
 
 int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d);
 
@@ -176,14 +177,14 @@ int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d);
  * @param priority
  * @return int 0 on success, -1 on failure
  */
-int shv_create_process_thread(int thrd_prio, shv_con_ctx_t *ctx);
+int shv_create_process_thread(int thrd_prio, struct shv_con_ctx *ctx);
 
 /**
  * @brief Platform dependant function. Stops the communication processing thread.
  *
  * @param shv_ctx
  */
-void shv_stop_process_thread(shv_con_ctx_t *shv_ctx);
+void shv_stop_process_thread(struct shv_con_ctx *shv_ctx);
 
 /**
  * @brief Allocate and initialize a shv_com_ctx_t struct.
@@ -193,7 +194,7 @@ void shv_stop_process_thread(shv_con_ctx_t *shv_ctx);
  * @param at_signlr
  * @return nonNULL pointer on success, NULL on failure
  */
-shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *con_info,
+struct shv_con_ctx *shv_com_init(struct shv_node *root, struct shv_connection *con_info,
                             shv_attention_signaller at_signlr);
 
 /**
@@ -201,7 +202,7 @@ shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *con_in
  *
  * @param shv_ctx
  */
-void shv_com_destroy(shv_con_ctx_t *shv_ctx);
+void shv_com_destroy(struct shv_con_ctx *shv_ctx);
 
 /**
  * @brief Launched in a separate thread, this function handles the connection to the broker.
@@ -212,4 +213,4 @@ void shv_com_destroy(shv_con_ctx_t *shv_ctx);
  * @param shv_ctx
  * @return 0 on success, -1 on failure
  */
-int shv_process(shv_con_ctx_t *shv_ctx);
+int shv_process(struct shv_con_ctx *shv_ctx);

--- a/libs4c/libshvtree/include/shv/tree/shv_com_common.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_com_common.h
@@ -14,7 +14,7 @@
 #include <stddef.h>
 #include <shv/chainpack/ccpcp.h>
 
-typedef struct shv_con_ctx shv_con_ctx_t;
+struct shv_con_ctx;
 
 /**
  * @brief A handler responsible for the sending of data
@@ -39,7 +39,7 @@ size_t shv_underrflow_handler(struct ccpcp_unpack_context * ctx);
  * @param shv_ctx
  * @param rid
  */
-void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid);
+void shv_pack_head_reply(struct shv_con_ctx *shv_ctx, int rid);
 
 /**
  * @brief Discard data of arbitrary type (container, string, blob).
@@ -48,4 +48,4 @@ void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid);
  * @param shv_ctx
  * @return 0 in case of success, -1 in case of failure
  */
-int shv_unpack_discard(shv_con_ctx_t * shv_ctx);
+int shv_unpack_discard(struct shv_con_ctx * shv_ctx);

--- a/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
@@ -19,7 +19,8 @@
  */
 typedef int (*shv_dotapp_node_date)(void);
 
-typedef struct shv_dotapp_node {
+struct shv_dotapp_node
+{
     struct shv_node shv_node;      /* Base shv_node */
     struct {
         shv_dotapp_node_date date; /* Date function callback */
@@ -27,7 +28,7 @@ typedef struct shv_dotapp_node {
 
     const char *name;              /* Application's name */
     const char *version;           /* Application's version */
-} shv_dotapp_node_t;
+};
 
 extern const struct shv_method_des shv_dmap_item_dotapp_shvversionmajor;
 extern const struct shv_method_des shv_dmap_item_dotapp_shvversionminor;
@@ -49,4 +50,4 @@ extern const struct shv_dmap shv_dotapp_dmap;
  * @param mode
  * @return non NULL reference on success, NULL otherwise
  */
-shv_dotapp_node_t *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode);
+struct shv_dotapp_node *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
@@ -20,7 +20,7 @@
 typedef int (*shv_dotapp_node_date)(void);
 
 typedef struct shv_dotapp_node {
-    shv_node_t shv_node;           /* Base shv_node */
+    struct shv_node shv_node;      /* Base shv_node */
     struct {
         shv_dotapp_node_date date; /* Date function callback */
     } appops;

--- a/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
@@ -40,7 +40,7 @@ extern const shv_method_des_t shv_dmap_item_dotapp_date;
  * @brief The dotapp method structure.
  *
  */
-extern const shv_dmap_t shv_dotapp_dmap;
+extern const struct shv_dmap shv_dotapp_dmap;
 
 /**
  * @brief Allocate a new standard .app node
@@ -49,4 +49,4 @@ extern const shv_dmap_t shv_dotapp_dmap;
  * @param mode
  * @return non NULL reference on success, NULL otherwise
  */
-shv_dotapp_node_t *shv_tree_dotapp_node_new(const shv_dmap_t *dir, int mode);
+shv_dotapp_node_t *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
@@ -29,12 +29,12 @@ typedef struct shv_dotapp_node {
     const char *version;           /* Application's version */
 } shv_dotapp_node_t;
 
-extern const shv_method_des_t shv_dmap_item_dotapp_shvversionmajor;
-extern const shv_method_des_t shv_dmap_item_dotapp_shvversionminor;
-extern const shv_method_des_t shv_dmap_item_dotapp_name;
-extern const shv_method_des_t shv_dmap_item_dotapp_version;
-extern const shv_method_des_t shv_dmap_item_dotapp_ping;
-extern const shv_method_des_t shv_dmap_item_dotapp_date;
+extern const struct shv_method_des shv_dmap_item_dotapp_shvversionmajor;
+extern const struct shv_method_des shv_dmap_item_dotapp_shvversionminor;
+extern const struct shv_method_des shv_dmap_item_dotapp_name;
+extern const struct shv_method_des shv_dmap_item_dotapp_version;
+extern const struct shv_method_des shv_dmap_item_dotapp_ping;
+extern const struct shv_method_des shv_dmap_item_dotapp_date;
 
 /**
  * @brief The dotapp method structure.

--- a/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
@@ -40,11 +40,11 @@ typedef struct shv_dotdevice_node {
     const char *version;
 } shv_dotdevice_node_t;
 
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_name;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_version;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_serial_number;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_uptime;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_reset;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_name;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_version;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_serial_number;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_uptime;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_reset;
 
 /**
  * @brief The dotdevice method structure.

--- a/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
@@ -29,7 +29,7 @@ typedef int (*shv_dotdevice_node_uptime)(void);
 typedef int (*shv_dotdevice_node_reset)(void);
 
 typedef struct shv_dotdevice_node {
-    shv_node_t shv_node;                  /* Base shv_node */
+    struct shv_node shv_node;             /* Base shv_node */
     struct {
         shv_dotdevice_node_reset  reset;  /* Platform dependant reset function */
         shv_dotdevice_node_uptime uptime; /* Platform dependant uptime function */

--- a/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
@@ -50,7 +50,7 @@ extern const shv_method_des_t shv_dmap_item_dotdevice_node_reset;
  * @brief The dotdevice method structure.
  * 
  */
-extern const shv_dmap_t shv_dotdevice_dmap;
+extern const struct shv_dmap shv_dotdevice_dmap;
 
 /**
  * @brief Allocate a new standard .dotdevice node
@@ -59,4 +59,4 @@ extern const shv_dmap_t shv_dotdevice_dmap;
  * @param mode 
  * @return non NULL reference on success, NULL otherwise
  */
-shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const shv_dmap_t *dir, int mode);
+shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
@@ -14,7 +14,7 @@
 #include "shv_tree.h"
 
 /* Forward declaration */
-typedef struct shv_dotdevice_node shv_dotdevice_node_t;
+struct shv_dotdevice_node;
 
 /**
  * @brief A platform dependant function used to track time.
@@ -28,7 +28,8 @@ typedef int (*shv_dotdevice_node_uptime)(void);
  */
 typedef int (*shv_dotdevice_node_reset)(void);
 
-typedef struct shv_dotdevice_node {
+struct shv_dotdevice_node
+{
     struct shv_node shv_node;             /* Base shv_node */
     struct {
         shv_dotdevice_node_reset  reset;  /* Platform dependant reset function */
@@ -38,7 +39,7 @@ typedef struct shv_dotdevice_node {
     const char *name;                     /* */
     const char *serial_number;
     const char *version;
-} shv_dotdevice_node_t;
+};
 
 extern const struct shv_method_des shv_dmap_item_dotdevice_node_name;
 extern const struct shv_method_des shv_dmap_item_dotdevice_node_version;
@@ -59,4 +60,4 @@ extern const struct shv_dmap shv_dotdevice_dmap;
  * @param mode 
  * @return non NULL reference on success, NULL otherwise
  */
-shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode);
+struct shv_dotdevice_node *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_file_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_file_node.h
@@ -86,7 +86,7 @@ typedef int (*shv_file_node_crc32)(struct shv_file_node *item, int start, size_t
 
 struct shv_file_node
 {
-    shv_node_t shv_node;                /* Base shv_node */
+    struct shv_node shv_node;           /* Base shv_node */
     const char *name;                   /* File name, system-wise */
     void *fctx;                         /* Platform dependant file context, can be overriden */
     struct

--- a/libs4c/libshvtree/include/shv/tree/shv_file_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_file_node.h
@@ -173,24 +173,24 @@ int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_n
  * @brief A wrapper of `shv_file_process_write` to be used
  *        as the file node's write method
  */
-extern const shv_method_des_t shv_dmap_item_file_node_write;
+extern const struct shv_method_des shv_dmap_item_file_node_write;
 
 /**
  * @brief A wrapper of `shv_file_process_crc32` to be used
  *        as the file node's crc method
  */
-extern const shv_method_des_t shv_dmap_item_file_node_crc;
+extern const struct shv_method_des shv_dmap_item_file_node_crc;
 
 /**
  * @brief A wrapper to be used as the file node's size method
  */
-extern const shv_method_des_t shv_dmap_item_file_node_size;
+extern const struct shv_method_des shv_dmap_item_file_node_size;
 
 /**
  * @brief A wrapper of `shv_file_send_stat` to be used
  *        as the file node's stat method
  */
-extern const shv_method_des_t shv_dmap_item_file_node_stat;
+extern const struct shv_method_des shv_dmap_item_file_node_stat;
 
 /**
  * @brief The file node method structure.

--- a/libs4c/libshvtree/include/shv/tree/shv_file_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_file_node.h
@@ -23,21 +23,22 @@ enum shv_file_type
     SHV_FILE_TYPE_COUNT,
 };
 
-typedef struct shv_file_node shv_file_node_t;
+/* Forward declaration */
+struct shv_file_node;
 
 /**
  * @brief A platform dependant function used to open the file
  * @param item
  * @return 0 in case of success, -1 otherwise
  */
-typedef int (*shv_file_node_opener)(shv_file_node_t *item);
+typedef int (*shv_file_node_opener)(struct shv_file_node *item);
 
 /**
  * @brief A platform dependant function used to get file's current size
  * @param item
  * @return file's size in case of success, -1 otherwise
  */
-typedef int (*shv_file_node_getsize)(shv_file_node_t *item);
+typedef int (*shv_file_node_getsize)(struct shv_file_node *item);
 
 /**
  * @brief A platform dependant function used to write count bytes from buf to a file
@@ -47,7 +48,7 @@ typedef int (*shv_file_node_getsize)(shv_file_node_t *item);
  * @warning The function must assure it does not write beyond the bounds of file_maxsize.
  * @return written bytes in case of success, -1 otherwise
  */
-typedef int (*shv_file_node_writer)(shv_file_node_t *item, void *buf, size_t count);
+typedef int (*shv_file_node_writer)(struct shv_file_node *item, void *buf, size_t count);
 
 /**
  * @brief A platform dependant function used to read count bytes from a file to buf
@@ -57,7 +58,7 @@ typedef int (*shv_file_node_writer)(shv_file_node_t *item, void *buf, size_t cou
  * @warning The function must assure it does not read outside the bounds of file_maxsize.
  * @return read bytes in case of success, -1 otherwise
  */
-typedef int (*shv_file_node_reader)(shv_file_node_t *item, void *buf, size_t count);
+typedef int (*shv_file_node_reader)(struct shv_file_node *item, void *buf, size_t count);
 
 /**
  * @typedef shv_file_node_seeker
@@ -67,7 +68,7 @@ typedef int (*shv_file_node_reader)(shv_file_node_t *item, void *buf, size_t cou
  * @warning The function must assure it does not seek beyond the bounds of file_maxsize.
  * @return the new offset in case of success, -1 otherwise
  */
-typedef int (*shv_file_node_seeker)(shv_file_node_t *item, int offset);
+typedef int (*shv_file_node_seeker)(struct shv_file_node *item, int offset);
 
 /**
  * @brief A function used to calculate CRC32 from start to start+size-1 specified by
@@ -80,43 +81,45 @@ typedef int (*shv_file_node_seeker)(shv_file_node_t *item, int offset);
  * @param result Pointer to the CRC32 result
  * @return 0 in case of success, -1 otherwise
  */
-typedef int (*shv_file_node_crc32)(shv_file_node_t *item, int start, size_t size,
+typedef int (*shv_file_node_crc32)(struct shv_file_node *item, int start, size_t size,
                                    uint32_t *result);
 
-typedef struct shv_file_node {
-  shv_node_t shv_node;                /* Base shv_node */
-  const char *name;                   /* File name, system-wise */
-  void *fctx;                         /* Platform dependant file context, can be overriden */
-  struct {
-    shv_file_node_opener  opener;
-    shv_file_node_getsize getsize;
-    shv_file_node_writer  writer;
-    shv_file_node_reader  reader;
-    shv_file_node_seeker  seeker;
-    shv_file_node_crc32   crc32;
-  } fops;
+struct shv_file_node
+{
+    shv_node_t shv_node;                /* Base shv_node */
+    const char *name;                   /* File name, system-wise */
+    void *fctx;                         /* Platform dependant file context, can be overriden */
+    struct
+    {
+        shv_file_node_opener  opener;
+        shv_file_node_getsize getsize;
+        shv_file_node_writer  writer;
+        shv_file_node_reader  reader;
+        shv_file_node_seeker  seeker;
+        shv_file_node_crc32   crc32;
+    } fops;
 
-  /* Stat method attributes */
-  int file_type;                      /* Defined in shv_file_type */
-  int file_maxsize;                   /* The implementation allows the file to grow,
-                                         but not beyond the absolute maximum size */
-  int file_pagesize;                  /* Page size on a given filesystem/physical memory
-                                         for efficient write accesses */
-  int file_erasesize;                 /* Page erase size (only for the MTD file type) */
+    /* Stat method attributes */
+    int file_type;                      /* Defined in shv_file_type */
+    int file_maxsize;                   /* The implementation allows the file to grow,
+                                           but not beyond the absolute maximum size */
+    int file_pagesize;                  /* Page size on a given filesystem/physical memory
+                                           for efficient write accesses */
+    int file_erasesize;                 /* Page erase size (only for the MTD file type) */
 
-  unsigned int state;                 /* Internal unpack write state */
-  int file_offset;                    /* Internal current file offset */
+    unsigned int state;                 /* Internal unpack write state */
+    int file_offset;                    /* Internal current file offset */
 
-  unsigned int crcstate;              /* Internal unpack crc state */
-  uint32_t crc;                       /* Internal CRC accumulator */
-  int crc_offset;                     /* Internal file CRC compute region */
-  int crc_size;                       /* Internal file CRC compute region */
+    unsigned int crcstate;              /* Internal unpack crc state */
+    uint32_t crc;                       /* Internal CRC accumulator */
+    int crc_offset;                     /* Internal file CRC compute region */
+    int crc_size;                       /* Internal file CRC compute region */
 
-  bool platform_error;                /* A flag to indicate that something bad in the platform
-                                         has happened. It does not indicate faulty data,
-                                         it only indicates that the unpack should
-                                         take this into consideration. */
-} shv_file_node_t;
+    bool platform_error;                /* A flag to indicate that something bad in the platform
+                                           has happened. It does not indicate faulty data,
+                                           it only indicates that the unpack should
+                                           take this into consideration. */
+};
 
 /**
  * @brief Packs the file's attributes and sends it
@@ -125,7 +128,7 @@ typedef struct shv_file_node {
  * @param rid 
  * @param item 
  */
-void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
+void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item);
 
 /**
  * @brief Reads the data from the file and sends them
@@ -134,7 +137,7 @@ void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *i
  * @param rid
  * @param item
  */
-void shv_file_send_read_data(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
+void shv_file_send_read_data(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item);
 
 /**
  * @brief Unpacks the incoming data and writes them to a file
@@ -144,7 +147,7 @@ void shv_file_send_read_data(struct shv_con_ctx *shv_ctx, int rid, shv_file_node
  * @param item 
  * @return 0 in case of success, -1 in case of garbled data
  */
-int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
+int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item);
 
 /**
  * @brief Unpacks the incoming data of the read method
@@ -154,7 +157,7 @@ int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t
  * @param item 
  * @return int 
  */
-int shv_file_process_read(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
+int shv_file_process_read(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item);
 
 /**
  * @brief Unpacks the desired CRC computation method and computes the CRC
@@ -164,7 +167,7 @@ int shv_file_process_read(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t 
  * @param item
  * @return int
  */
-int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
+int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item);
 
 /**
  * @brief A wrapper of `shv_file_process_write` to be used
@@ -203,4 +206,4 @@ extern const shv_dmap_t shv_file_node_dmap;
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-shv_file_node_t *shv_tree_file_node_new(const char *child_name, const shv_dmap_t *dir, int mode);
+struct shv_file_node *shv_tree_file_node_new(const char *child_name, const shv_dmap_t *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_file_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_file_node.h
@@ -13,7 +13,7 @@
 
 #include "shv_tree.h"
 
-typedef struct shv_con_ctx shv_con_ctx_t;
+struct shv_con_ctx;
 
 /* File type identification enum */
 enum shv_file_type
@@ -125,7 +125,7 @@ typedef struct shv_file_node {
  * @param rid 
  * @param item 
  */
-void shv_file_send_stat(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item);
+void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
 
 /**
  * @brief Reads the data from the file and sends them
@@ -134,7 +134,7 @@ void shv_file_send_stat(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item);
  * @param rid
  * @param item
  */
-void shv_file_send_read_data(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item);
+void shv_file_send_read_data(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
 
 /**
  * @brief Unpacks the incoming data and writes them to a file
@@ -144,7 +144,7 @@ void shv_file_send_read_data(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *i
  * @param item 
  * @return 0 in case of success, -1 in case of garbled data
  */
-int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item);
+int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
 
 /**
  * @brief Unpacks the incoming data of the read method
@@ -154,7 +154,7 @@ int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *ite
  * @param item 
  * @return int 
  */
-int shv_file_process_read(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item);
+int shv_file_process_read(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
 
 /**
  * @brief Unpacks the desired CRC computation method and computes the CRC
@@ -164,7 +164,7 @@ int shv_file_process_read(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item
  * @param item
  * @return int
  */
-int shv_file_process_crc(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item);
+int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item);
 
 /**
  * @brief A wrapper of `shv_file_process_write` to be used

--- a/libs4c/libshvtree/include/shv/tree/shv_file_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_file_node.h
@@ -196,7 +196,7 @@ extern const shv_method_des_t shv_dmap_item_file_node_stat;
  * @brief The file node method structure.
  *
  */
-extern const shv_dmap_t shv_file_node_dmap;
+extern const struct shv_dmap shv_file_node_dmap;
 
 /**
  * @brief Allocates and initializes a file node
@@ -206,4 +206,4 @@ extern const shv_dmap_t shv_file_node_dmap;
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-struct shv_file_node *shv_tree_file_node_new(const char *child_name, const shv_dmap_t *dir, int mode);
+struct shv_file_node *shv_tree_file_node_new(const char *child_name, const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_methods.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_methods.h
@@ -36,8 +36,8 @@ extern const struct shv_dmap shv_double_read_only_dmap;
 extern const struct shv_dmap shv_dir_ls_dmap;
 extern const struct shv_dmap shv_root_dmap;
 
-int shv_ls(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
-int shv_dir(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
-int shv_type(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
-int shv_double_get(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
-int shv_double_set(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
+int shv_ls(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_dir(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_type(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_double_get(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_double_set(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);

--- a/libs4c/libshvtree/include/shv/tree/shv_methods.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_methods.h
@@ -28,8 +28,8 @@
 #define SHV_ACCESS_WRITE   ((int)16)
 #define SHV_ACCESS_COMMAND ((int)24)
 
-extern const shv_method_des_t shv_dmap_item_ls;
-extern const shv_method_des_t shv_dmap_item_dir;
+extern const struct shv_method_des shv_dmap_item_ls;
+extern const struct shv_method_des shv_dmap_item_dir;
 
 extern const struct shv_dmap shv_double_dmap;
 extern const struct shv_dmap shv_double_read_only_dmap;

--- a/libs4c/libshvtree/include/shv/tree/shv_methods.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_methods.h
@@ -31,10 +31,10 @@
 extern const shv_method_des_t shv_dmap_item_ls;
 extern const shv_method_des_t shv_dmap_item_dir;
 
-extern const shv_dmap_t shv_double_dmap;
-extern const shv_dmap_t shv_double_read_only_dmap;
-extern const shv_dmap_t shv_dir_ls_dmap;
-extern const shv_dmap_t shv_root_dmap;
+extern const struct shv_dmap shv_double_dmap;
+extern const struct shv_dmap shv_double_read_only_dmap;
+extern const struct shv_dmap shv_dir_ls_dmap;
+extern const struct shv_dmap shv_root_dmap;
 
 int shv_ls(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
 int shv_dir(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);

--- a/libs4c/libshvtree/include/shv/tree/shv_methods.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_methods.h
@@ -36,8 +36,8 @@ extern const shv_dmap_t shv_double_read_only_dmap;
 extern const shv_dmap_t shv_dir_ls_dmap;
 extern const shv_dmap_t shv_root_dmap;
 
-int shv_ls(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_dir(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_type(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_double_get(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_double_set(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
+int shv_ls(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
+int shv_dir(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
+int shv_type(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
+int shv_double_get(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);
+int shv_double_set(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid);

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -78,14 +78,15 @@ struct shv_node_typed_val
 struct shv_con_ctx;
 typedef int (* shv_method_t) (struct shv_con_ctx *ctx, struct shv_node * node, int rid);
 
-typedef struct shv_method_des {
+struct shv_method_des
+{
   const char *name;       /* Method name */
   const int flags;        /* Method flags */
   const char *param;      /* Parameter type for request */
   const char *result;     /* Result type for responses */
   const int access;       /* Access level */
   shv_method_t method;    /* Pointer to the method function */
-} shv_method_des_t;
+};
 
 typedef const char *shv_node_list_key_t;
 typedef const char *shv_method_des_key_t;
@@ -112,7 +113,7 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
   return strcmp(*a, *b);
 }
 
-GSA_CUST_DEC(shv_dmap, struct shv_dmap, shv_method_des_t, shv_method_des_key_t,
+GSA_CUST_DEC(shv_dmap, struct shv_dmap, struct shv_method_des, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
 typedef struct shv_node_list_it

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -52,9 +52,9 @@ struct shv_node_list
   } list;
 };
 
-typedef struct shv_dmap {
+struct shv_dmap {
   gsa_array_field_t methods;  /* GSA array of methods */
-} shv_dmap_t;
+};
 
 typedef struct shv_node shv_node_t;
 typedef struct shv_node {
@@ -63,7 +63,7 @@ typedef struct shv_node {
   } vtable;                      /* Node vtable */
   const char *name;              /* Node name */
   gavl_node_t gavl_node;         /* GAVL instance */
-  shv_dmap_t *dir;               /* Pointer to supported methods */
+  struct shv_dmap *dir;          /* Pointer to supported methods */
   struct shv_node_list children; /* List of node children */
 } shv_node_t;
 
@@ -110,7 +110,7 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
   return strcmp(*a, *b);
 }
 
-GSA_CUST_DEC(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
+GSA_CUST_DEC(shv_dmap, struct shv_dmap, shv_method_des_t, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
 typedef struct shv_node_list_it
@@ -151,7 +151,7 @@ void shv_node_list_names_it_init(struct shv_node_list *list, shv_node_list_names
 int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char * met, const char * path);
 shv_node_t *shv_node_find(shv_node_t *node, const char * path);
 void shv_tree_add_child(shv_node_t *node, shv_node_t *child);
-void shv_tree_node_init(shv_node_t *item, const char *child_name, const shv_dmap_t *dir, int mode);
+void shv_tree_node_init(shv_node_t *item, const char *child_name, const struct shv_dmap *dir, int mode);
 
 /**
  * @brief Destroy the whole SHV tree, given the parent node
@@ -168,7 +168,7 @@ void shv_tree_destroy(shv_node_t *parent);
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-shv_node_t *shv_tree_node_new(const char *child_name, const shv_dmap_t *dir, int mode);
+shv_node_t *shv_tree_node_new(const char *child_name, const struct shv_dmap *dir, int mode);
 
 /**
  * @brief Initialize the shv_node_typed_val_t node
@@ -178,4 +178,4 @@ shv_node_t *shv_tree_node_new(const char *child_name, const shv_dmap_t *dir, int
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name, const shv_dmap_t *dir, int mode);
+shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name, const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -116,18 +116,18 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
 GSA_CUST_DEC(shv_dmap, struct shv_dmap, struct shv_method_des, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
-typedef struct shv_node_list_it
+struct shv_node_list_it
 {
   struct shv_node_list *node_list;
   union {
     struct shv_node *gavl_next_node;
     int gsa_next_indx;
   } list_it;
-} shv_node_list_it_t;
+};
 
-void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it);
-void shv_node_list_it_reset(shv_node_list_it_t *it);
-struct shv_node *shv_node_list_it_next(shv_node_list_it_t *it);
+void shv_node_list_it_init(struct shv_node_list *list, struct shv_node_list_it *it);
+void shv_node_list_it_reset(struct shv_node_list_it *it);
+struct shv_node *shv_node_list_it_next(struct shv_node_list_it *it);
 
 static inline int
 shv_node_list_count(struct shv_node_list *node_list)
@@ -145,7 +145,7 @@ shv_node_list_count(struct shv_node_list *node_list)
 struct shv_node_list_names_it
 {
   struct shv_str_list_it str_it;
-  shv_node_list_it_t list_it;
+  struct shv_node_list_it list_it;
 };
 
 void shv_node_list_names_it_init(struct shv_node_list *list, struct shv_node_list_names_it *names_it);

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -38,7 +38,8 @@
         }\
     }
 
-typedef struct shv_node_list {
+struct shv_node_list
+{
   int mode;                         /* Mode selection (GAVL vs GSA, static vs dynamic) */
   union {
     struct {
@@ -49,7 +50,7 @@ typedef struct shv_node_list {
       gsa_array_field_t root;       /* GSA root */
     } gsa;
   } list;
-} shv_node_list_t;
+};
 
 typedef struct shv_dmap {
   gsa_array_field_t methods;  /* GSA array of methods */
@@ -59,11 +60,11 @@ typedef struct shv_node shv_node_t;
 typedef struct shv_node {
   struct {
     void (*destructor)(shv_node_t *this);
-  } vtable;                 /* Node vtable */
-  const char *name;         /* Node name */
-  gavl_node_t gavl_node;    /* GAVL instance */
-  shv_dmap_t *dir;          /* Pointer to supported methods */
-  shv_node_list_t children; /* List of node children */
+  } vtable;                      /* Node vtable */
+  const char *name;              /* Node name */
+  gavl_node_t gavl_node;         /* GAVL instance */
+  shv_dmap_t *dir;               /* Pointer to supported methods */
+  struct shv_node_list children; /* List of node children */
 } shv_node_t;
 
 typedef struct shv_node_typed_val {
@@ -91,10 +92,10 @@ typedef const char *shv_method_des_key_t;
 /* GAVL_CUST_NODE_INT_DEC - standard custom tree with internal node */
 /* GAVL_FLES_INT_DEC      - tree with enhanced first last access speed  */
 
-GAVL_CUST_NODE_INT_DEC(shv_node_list_gavl, shv_node_list_t, shv_node_t, shv_node_list_key_t,
+GAVL_CUST_NODE_INT_DEC(shv_node_list_gavl, struct shv_node_list, shv_node_t, shv_node_list_key_t,
 	list.gavl.root, gavl_node, name, shv_node_list_comp_func)
 
-GSA_CUST_DEC(shv_node_list_gsa, shv_node_list_t, shv_node_t, shv_node_list_key_t,
+GSA_CUST_DEC(shv_node_list_gsa, struct shv_node_list, shv_node_t, shv_node_list_key_t,
 	list.gsa.root, name, shv_node_list_comp_func)
 
 static inline int
@@ -112,21 +113,21 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
 GSA_CUST_DEC(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
-typedef struct shv_node_list_it
+struct shv_node_list_it
 {
-  shv_node_list_t *node_list;
+  struct shv_node_list *node_list;
   union {
     shv_node_t *gavl_next_node;
     int gsa_next_indx;
   } list_it;
-} shv_node_list_it_t;
+};
 
-void shv_node_list_it_init(shv_node_list_t *list, shv_node_list_it_t *it);
+void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it);
 void shv_node_list_it_reset(shv_node_list_it_t *it);
 shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it);
 
 static inline int
-shv_node_list_count(shv_node_list_t *node_list)
+shv_node_list_count(struct shv_node_list *node_list)
 {
   if (node_list->mode & SHV_NLIST_MODE_GSA)
     {
@@ -143,7 +144,7 @@ typedef struct shv_node_list_names_it_t {
   shv_node_list_it_t list_it;
 } shv_node_list_names_it_t;
 
-void shv_node_list_names_it_init(shv_node_list_t *list, shv_node_list_names_it_t *names_it);
+void shv_node_list_names_it_init(struct shv_node_list *list, shv_node_list_names_it_t *names_it);
 
 /* Public functions definition */
 

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -112,7 +112,8 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
 GSA_CUST_DEC(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
-typedef struct shv_node_list_it_t {
+typedef struct shv_node_list_it
+{
   shv_node_list_t *node_list;
   union {
     shv_node_t *gavl_next_node;
@@ -138,7 +139,7 @@ shv_node_list_count(shv_node_list_t *node_list)
 }
 
 typedef struct shv_node_list_names_it_t {
-  shv_str_list_it_t str_it;
+  struct shv_str_list_it str_it;
   shv_node_list_it_t list_it;
 } shv_node_list_names_it_t;
 

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -72,8 +72,8 @@ typedef struct shv_node_typed_val {
   char *type_name;              /* Type of the value (int, double...) */
 } shv_node_typed_val_t;
 
-typedef struct shv_con_ctx shv_con_ctx_t;
-typedef int (* shv_method_t) (shv_con_ctx_t *ctx, shv_node_t * node, int rid);
+struct shv_con_ctx;
+typedef int (* shv_method_t) (struct shv_con_ctx *ctx, shv_node_t * node, int rid);
 
 typedef struct shv_method_des {
   const char *name;       /* Method name */
@@ -146,7 +146,7 @@ void shv_node_list_names_it_init(shv_node_list_t *list, shv_node_list_names_it_t
 
 /* Public functions definition */
 
-int shv_node_process(shv_con_ctx_t *shv_ctx, int rid, const char * met, const char * path);
+int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char * met, const char * path);
 shv_node_t *shv_node_find(shv_node_t *node, const char * path);
 void shv_tree_add_child(shv_node_t *node, shv_node_t *child);
 void shv_tree_node_init(shv_node_t *item, const char *child_name, const shv_dmap_t *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -142,12 +142,13 @@ shv_node_list_count(struct shv_node_list *node_list)
     }
 }
 
-typedef struct shv_node_list_names_it_t {
+struct shv_node_list_names_it
+{
   struct shv_str_list_it str_it;
   shv_node_list_it_t list_it;
-} shv_node_list_names_it_t;
+};
 
-void shv_node_list_names_it_init(struct shv_node_list *list, shv_node_list_names_it_t *names_it);
+void shv_node_list_names_it_init(struct shv_node_list *list, struct shv_node_list_names_it *names_it);
 
 /* Public functions definition */
 

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -113,14 +113,14 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
 GSA_CUST_DEC(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
-struct shv_node_list_it
+typedef struct shv_node_list_it
 {
   struct shv_node_list *node_list;
   union {
     shv_node_t *gavl_next_node;
     int gsa_next_indx;
   } list_it;
-};
+} shv_node_list_it_t;
 
 void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it);
 void shv_node_list_it_reset(shv_node_list_it_t *it);

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -68,11 +68,12 @@ struct shv_node
   struct shv_node_list children; /* List of node children */
 };
 
-typedef struct shv_node_typed_val {
+struct shv_node_typed_val
+{
   struct shv_node shv_node;     /* Node instance */
   void *val_ptr;                /* Double value */
   char *type_name;              /* Type of the value (int, double...) */
-} shv_node_typed_val_t;
+};
 
 struct shv_con_ctx;
 typedef int (* shv_method_t) (struct shv_con_ctx *ctx, struct shv_node * node, int rid);
@@ -172,11 +173,11 @@ void shv_tree_destroy(struct shv_node *parent);
 struct shv_node *shv_tree_node_new(const char *child_name, const struct shv_dmap *dir, int mode);
 
 /**
- * @brief Initialize the shv_node_typed_val_t node
+ * @brief Initialize the struct shv_node_typed_val node
  *
  * @param child_name
  * @param dir
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name, const struct shv_dmap *dir, int mode);
+struct shv_node_typed_val *shv_tree_node_typed_val_new(const char *child_name, const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -56,25 +56,26 @@ struct shv_dmap {
   gsa_array_field_t methods;  /* GSA array of methods */
 };
 
-typedef struct shv_node shv_node_t;
-typedef struct shv_node {
+struct shv_node;
+struct shv_node
+{
   struct {
-    void (*destructor)(shv_node_t *this);
+    void (*destructor)(struct shv_node *this);
   } vtable;                      /* Node vtable */
   const char *name;              /* Node name */
   gavl_node_t gavl_node;         /* GAVL instance */
   struct shv_dmap *dir;          /* Pointer to supported methods */
   struct shv_node_list children; /* List of node children */
-} shv_node_t;
+};
 
 typedef struct shv_node_typed_val {
-  shv_node_t shv_node;          /* Node instance */
+  struct shv_node shv_node;     /* Node instance */
   void *val_ptr;                /* Double value */
   char *type_name;              /* Type of the value (int, double...) */
 } shv_node_typed_val_t;
 
 struct shv_con_ctx;
-typedef int (* shv_method_t) (struct shv_con_ctx *ctx, shv_node_t * node, int rid);
+typedef int (* shv_method_t) (struct shv_con_ctx *ctx, struct shv_node * node, int rid);
 
 typedef struct shv_method_des {
   const char *name;       /* Method name */
@@ -92,10 +93,10 @@ typedef const char *shv_method_des_key_t;
 /* GAVL_CUST_NODE_INT_DEC - standard custom tree with internal node */
 /* GAVL_FLES_INT_DEC      - tree with enhanced first last access speed  */
 
-GAVL_CUST_NODE_INT_DEC(shv_node_list_gavl, struct shv_node_list, shv_node_t, shv_node_list_key_t,
+GAVL_CUST_NODE_INT_DEC(shv_node_list_gavl, struct shv_node_list, struct shv_node, shv_node_list_key_t,
 	list.gavl.root, gavl_node, name, shv_node_list_comp_func)
 
-GSA_CUST_DEC(shv_node_list_gsa, struct shv_node_list, shv_node_t, shv_node_list_key_t,
+GSA_CUST_DEC(shv_node_list_gsa, struct shv_node_list, struct shv_node, shv_node_list_key_t,
 	list.gsa.root, name, shv_node_list_comp_func)
 
 static inline int
@@ -117,14 +118,14 @@ typedef struct shv_node_list_it
 {
   struct shv_node_list *node_list;
   union {
-    shv_node_t *gavl_next_node;
+    struct shv_node *gavl_next_node;
     int gsa_next_indx;
   } list_it;
 } shv_node_list_it_t;
 
 void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it);
 void shv_node_list_it_reset(shv_node_list_it_t *it);
-shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it);
+struct shv_node *shv_node_list_it_next(shv_node_list_it_t *it);
 
 static inline int
 shv_node_list_count(struct shv_node_list *node_list)
@@ -149,16 +150,16 @@ void shv_node_list_names_it_init(struct shv_node_list *list, shv_node_list_names
 /* Public functions definition */
 
 int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char * met, const char * path);
-shv_node_t *shv_node_find(shv_node_t *node, const char * path);
-void shv_tree_add_child(shv_node_t *node, shv_node_t *child);
-void shv_tree_node_init(shv_node_t *item, const char *child_name, const struct shv_dmap *dir, int mode);
+struct shv_node *shv_node_find(struct shv_node *node, const char * path);
+void shv_tree_add_child(struct shv_node *node, struct shv_node *child);
+void shv_tree_node_init(struct shv_node *item, const char *child_name, const struct shv_dmap *dir, int mode);
 
 /**
  * @brief Destroy the whole SHV tree, given the parent node
  *
  * @param parent
  */
-void shv_tree_destroy(shv_node_t *parent);
+void shv_tree_destroy(struct shv_node *parent);
 
 /**
  * @brief Allocates and initializes a simple node
@@ -168,7 +169,7 @@ void shv_tree_destroy(shv_node_t *parent);
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-shv_node_t *shv_tree_node_new(const char *child_name, const struct shv_dmap *dir, int mode);
+struct shv_node *shv_tree_node_new(const char *child_name, const struct shv_dmap *dir, int mode);
 
 /**
  * @brief Initialize the shv_node_typed_val_t node

--- a/libs4c/libshvtree/shv_clayer_posix.c
+++ b/libs4c/libshvtree/shv_clayer_posix.c
@@ -390,7 +390,7 @@ int shv_tcpip_posix_dataready(struct shv_connection *connection, int timeout)
 
 static void *__shv_process(void *arg)
 {
-    shv_con_ctx_t *shv_ctx = (shv_con_ctx_t *)arg;
+    struct shv_con_ctx *shv_ctx = (struct shv_con_ctx *)arg;
     shv_ctx->thrd_ctx.thrd_ret = shv_process(shv_ctx);
     /* Report a hard error */
     if (shv_ctx->thrd_ctx.thrd_ret == -1 && shv_ctx->at_signlr != NULL) {
@@ -399,7 +399,7 @@ static void *__shv_process(void *arg)
     return NULL;
 }
 
-int shv_create_process_thread(int thrd_prio, shv_con_ctx_t *ctx)
+int shv_create_process_thread(int thrd_prio, struct shv_con_ctx *ctx)
 {
     int ret;
     int policy;
@@ -449,7 +449,7 @@ error:
     return -1;
 }
 
-void shv_stop_process_thread(shv_con_ctx_t *shv_ctx)
+void shv_stop_process_thread(struct shv_con_ctx *shv_ctx)
 {
     /* Write to the pipe to simulate the instant timeout */
     /* The write is enclosed in {} to suppress warn_unused_result warning */

--- a/libs4c/libshvtree/shv_clayer_posix.c
+++ b/libs4c/libshvtree/shv_clayer_posix.c
@@ -50,7 +50,7 @@
 #define RETLZ_ERROR(__err_label) if (ret < 0) goto __err_label
 #define CHUNK_SIZE ((size_t)64)
 
-int shv_file_node_posix_opener(shv_file_node_t *item)
+int shv_file_node_posix_opener(struct shv_file_node *item)
 {
     struct shv_file_node_fctx *fctx = (struct shv_file_node_fctx*) item->fctx;
     if (!(fctx->flags & SHV_FILE_POSIX_BITFLAG_OPENED)) {
@@ -64,7 +64,7 @@ int shv_file_node_posix_opener(shv_file_node_t *item)
     return 0;
 }
 
-int shv_file_node_posix_getsize(shv_file_node_t *item)
+int shv_file_node_posix_getsize(struct shv_file_node *item)
 {
     struct stat st;
     if (stat(item->name, &st) < 0) {
@@ -73,7 +73,7 @@ int shv_file_node_posix_getsize(shv_file_node_t *item)
     return st.st_size;
 }
 
-int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count)
+int shv_file_node_posix_writer(struct shv_file_node *item, void *buf, size_t count)
 {
     struct shv_file_node_fctx *fctx = (struct shv_file_node_fctx*) item->fctx;
 
@@ -90,7 +90,7 @@ int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count)
     return -1;
 }
 
-int shv_file_node_posix_seeker(shv_file_node_t *item, int offset)
+int shv_file_node_posix_seeker(struct shv_file_node *item, int offset)
 {
     struct shv_file_node_fctx *fctx = (struct shv_file_node_fctx*) item->fctx;
 
@@ -104,7 +104,7 @@ int shv_file_node_posix_seeker(shv_file_node_t *item, int offset)
     return -1;
 }
 
-int shv_file_node_posix_crc32(shv_file_node_t *item, int start, size_t size, uint32_t *result)
+int shv_file_node_posix_crc32(struct shv_file_node *item, int start, size_t size, uint32_t *result)
 {
     /* The calculation between Linux and NuttX differs a bit. While both implementations
      * use the IEEE 802.3, the process is a bit different.

--- a/libs4c/libshvtree/shv_com.c
+++ b/libs4c/libshvtree/shv_com.c
@@ -636,7 +636,7 @@ void shv_send_str_list(struct shv_con_ctx *shv_ctx, int rid, int num_str,
  ****************************************************************************/
 
 void shv_send_str_list_it(struct shv_con_ctx *shv_ctx, int rid, int num_str,
-                          shv_str_list_it_t *str_it)
+                          struct shv_str_list_it *str_it)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);

--- a/libs4c/libshvtree/shv_com.c
+++ b/libs4c/libshvtree/shv_com.c
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
-int cid_alloc(shv_con_ctx_t * shv_ctx)
+int cid_alloc(struct shv_con_ctx * shv_ctx)
 {
   if (shv_ctx->cid_capacity < shv_ctx->cid_cnt)
     {
@@ -74,7 +74,7 @@ int cid_alloc(shv_con_ctx_t * shv_ctx)
  *
  ****************************************************************************/
 
-void shv_pack_head_request(shv_con_ctx_t *shv_ctx, char *met, char *path)
+void shv_pack_head_request(struct shv_con_ctx *shv_ctx, char *met, char *path)
 {
   cchainpack_pack_meta_begin(&shv_ctx->pack_ctx);
 
@@ -101,7 +101,7 @@ void shv_pack_head_request(shv_con_ctx_t *shv_ctx, char *met, char *path)
  *
  ****************************************************************************/
 
-int shv_unpack_head(shv_con_ctx_t * shv_ctx, int * rid, char * method,
+int shv_unpack_head(struct shv_con_ctx * shv_ctx, int * rid, char * method,
                     char * path)
 {
   int i;
@@ -365,7 +365,7 @@ int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d)
  *
  ****************************************************************************/
 
-int shv_process_input(shv_con_ctx_t * shv_ctx)
+int shv_process_input(struct shv_con_ctx * shv_ctx)
 {
   int i;
   int j;
@@ -415,7 +415,7 @@ int shv_process_input(shv_con_ctx_t * shv_ctx)
  *
  ****************************************************************************/
 
-void shv_send_ping(shv_con_ctx_t *shv_ctx)
+void shv_send_ping(struct shv_con_ctx *shv_ctx)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx, shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -447,7 +447,7 @@ void shv_send_ping(shv_con_ctx_t *shv_ctx)
  *
  ****************************************************************************/
 
-void shv_send_int(shv_con_ctx_t *shv_ctx, int rid, int num)
+void shv_send_int(struct shv_con_ctx *shv_ctx, int rid, int num)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx, shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -472,7 +472,7 @@ void shv_send_int(shv_con_ctx_t *shv_ctx, int rid, int num)
     }
 }
 
-void shv_send_uint(shv_con_ctx_t *shv_ctx, int rid, unsigned int num)
+void shv_send_uint(struct shv_con_ctx *shv_ctx, int rid, unsigned int num)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx, shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -505,7 +505,7 @@ void shv_send_uint(shv_con_ctx_t *shv_ctx, int rid, unsigned int num)
  *
  ****************************************************************************/
 
-void shv_send_double(shv_con_ctx_t *shv_ctx, int rid, double num)
+void shv_send_double(struct shv_con_ctx *shv_ctx, int rid, double num)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data,
                           SHV_BUF_LEN,shv_overflow_handler);
@@ -538,7 +538,7 @@ void shv_send_double(shv_con_ctx_t *shv_ctx, int rid, double num)
  *
  ****************************************************************************/
 
-void shv_send_str(shv_con_ctx_t *shv_ctx, int rid, const char *str)
+void shv_send_str(struct shv_con_ctx *shv_ctx, int rid, const char *str)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -563,7 +563,7 @@ void shv_send_str(shv_con_ctx_t *shv_ctx, int rid, const char *str)
     }
 }
 
-void shv_send_empty_response(shv_con_ctx_t *shv_ctx, int rid)
+void shv_send_empty_response(struct shv_con_ctx *shv_ctx, int rid)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -594,7 +594,7 @@ void shv_send_empty_response(shv_con_ctx_t *shv_ctx, int rid)
  *
  ****************************************************************************/
 
-void shv_send_str_list(shv_con_ctx_t *shv_ctx, int rid, int num_str,
+void shv_send_str_list(struct shv_con_ctx *shv_ctx, int rid, int num_str,
                        const char **str)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
@@ -635,7 +635,7 @@ void shv_send_str_list(shv_con_ctx_t *shv_ctx, int rid, int num_str,
  *
  ****************************************************************************/
 
-void shv_send_str_list_it(shv_con_ctx_t *shv_ctx, int rid, int num_str,
+void shv_send_str_list_it(struct shv_con_ctx *shv_ctx, int rid, int num_str,
                           shv_str_list_it_t *str_it)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
@@ -697,7 +697,7 @@ void shv_send_str_list_it(shv_con_ctx_t *shv_ctx, int rid, int num_str,
  *
  ****************************************************************************/
 
-void shv_send_dir(shv_con_ctx_t *shv_ctx, const struct shv_dir_res *results,
+void shv_send_dir(struct shv_con_ctx *shv_ctx, const struct shv_dir_res *results,
                   int cnt, int rid)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
@@ -768,7 +768,7 @@ void shv_send_dir(shv_con_ctx_t *shv_ctx, const struct shv_dir_res *results,
  *
  ****************************************************************************/
 
-void shv_send_error(shv_con_ctx_t *shv_ctx, int rid, enum shv_response_error_code code,
+void shv_send_error(struct shv_con_ctx *shv_ctx, int rid, enum shv_response_error_code code,
                     const char *msg)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data,
@@ -814,7 +814,7 @@ void shv_send_error(shv_con_ctx_t *shv_ctx, int rid, enum shv_response_error_cod
  *
  ****************************************************************************/
 
-int shv_login(shv_con_ctx_t *shv_ctx)
+int shv_login(struct shv_con_ctx *shv_ctx)
 {
   int i;
   int id = 0;
@@ -1005,14 +1005,14 @@ int shv_login(shv_con_ctx_t *shv_ctx)
  * Name: shv_con_ctx_init
  *
  * Description:
- *   Fill the shv_con_ctx_t with variables.
+ *   Fill the struct shv_con_ctx with variables.
  *
  ****************************************************************************/
 
-void shv_con_ctx_init(shv_con_ctx_t *shv_ctx, struct shv_node *root,
+void shv_con_ctx_init(struct shv_con_ctx *shv_ctx, struct shv_node *root,
                       struct shv_connection *connection, shv_attention_signaller at_signlr)
 {
-  memset(shv_ctx, 0, sizeof(shv_con_ctx_t));
+  memset(shv_ctx, 0, sizeof(struct shv_con_ctx));
 
   shv_ctx->root = root;
   shv_ctx->timeout = 360;
@@ -1027,7 +1027,7 @@ void shv_con_ctx_init(shv_con_ctx_t *shv_ctx, struct shv_node *root,
  * @param shv_ctx
  * @return int
  */
-static inline int shv_process_communication(shv_con_ctx_t *shv_ctx)
+static inline int shv_process_communication(struct shv_con_ctx *shv_ctx)
 {
     int ret;
 
@@ -1072,7 +1072,7 @@ static inline int shv_process_communication(shv_con_ctx_t *shv_ctx)
     return ret;
 }
 
-int shv_process(shv_con_ctx_t *shv_ctx)
+int shv_process(struct shv_con_ctx *shv_ctx)
 {
     int ret;
     /* A local enum to keep track of the connection */
@@ -1177,10 +1177,10 @@ int shv_process(shv_con_ctx_t *shv_ctx)
  *
  ****************************************************************************/
 
-shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *connection,
+struct shv_con_ctx *shv_com_init(struct shv_node *root, struct shv_connection *connection,
                             shv_attention_signaller at_signlr)
 {
-  shv_con_ctx_t *shv_ctx = (shv_con_ctx_t *)malloc(sizeof(shv_con_ctx_t));
+  struct shv_con_ctx *shv_ctx = (struct shv_con_ctx *)malloc(sizeof(struct shv_con_ctx));
   if (shv_ctx == NULL)
     {
       printf("ERROR: Failed to allocate memory for shv_ctx\n");
@@ -1191,7 +1191,7 @@ shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *connec
   return shv_ctx;
 }
 
-void shv_com_destroy(shv_con_ctx_t *shv_ctx)
+void shv_com_destroy(struct shv_con_ctx *shv_ctx)
 {
     atomic_store(&shv_ctx->running, false);
     shv_tree_destroy(shv_ctx->root);

--- a/libs4c/libshvtree/shv_com_common.c
+++ b/libs4c/libshvtree/shv_com_common.c
@@ -23,7 +23,7 @@
 void shv_overflow_handler(struct ccpcp_pack_context *ctx, size_t size_hint)
 {
 
-  shv_con_ctx_t *shv_ctx = UL_CONTAINEROF(ctx, shv_con_ctx_t, pack_ctx);
+  struct shv_con_ctx *shv_ctx = UL_CONTAINEROF(ctx, struct shv_con_ctx, pack_ctx);
   size_t to_send = ctx->current - ctx->start;
   char * ptr_data = shv_ctx->shv_data;
   int ret = 0;
@@ -58,7 +58,7 @@ size_t shv_underrflow_handler(struct ccpcp_unpack_context * ctx)
 {
   int i;
 
-  shv_con_ctx_t *shv_ctx = UL_CONTAINEROF(ctx, shv_con_ctx_t, unpack_ctx);
+  struct shv_con_ctx *shv_ctx = UL_CONTAINEROF(ctx, struct shv_con_ctx, unpack_ctx);
 
   i = shv_ctx->connection->tops.read(shv_ctx->connection,
                                      shv_ctx->shv_rd_data, sizeof(shv_ctx->shv_rd_data));
@@ -72,7 +72,7 @@ size_t shv_underrflow_handler(struct ccpcp_unpack_context * ctx)
   return i;
 }
 
-void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid)
+void shv_pack_head_reply(struct shv_con_ctx *shv_ctx, int rid)
 {
   cchainpack_pack_meta_begin(&shv_ctx->pack_ctx);
 
@@ -108,7 +108,7 @@ void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid)
  * @param shv_ctx
  * @return 0 in case of success, -1 on failure
  */
-static int shv_unpack_contskip(shv_con_ctx_t *shv_ctx)
+static int shv_unpack_contskip(struct shv_con_ctx *shv_ctx)
 {
     struct ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
     int level = 1;
@@ -132,7 +132,7 @@ static int shv_unpack_contskip(shv_con_ctx_t *shv_ctx)
     return 0;
 }
 
-int shv_unpack_discard(shv_con_ctx_t * shv_ctx)
+int shv_unpack_discard(struct shv_con_ctx *shv_ctx)
 {
     struct ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
 

--- a/libs4c/libshvtree/shv_dotapp_node.c
+++ b/libs4c/libshvtree/shv_dotapp_node.c
@@ -18,21 +18,21 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int shv_dotapp_node_method_shvversionmajor(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_shvversionmajor(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 3);
     return 0;
 }
 
-int shv_dotapp_node_method_shvversionminor(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_shvversionminor(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 0);
     return 0;
 }
 
-int shv_dotapp_node_method_name(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -40,7 +40,7 @@ int shv_dotapp_node_method_name(struct shv_con_ctx *shv_ctx, shv_node_t *item, i
     return 0;
 }
 
-int shv_dotapp_node_method_version(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_version(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -48,14 +48,14 @@ int shv_dotapp_node_method_version(struct shv_con_ctx *shv_ctx, shv_node_t *item
     return 0;
 }
 
-int shv_dotapp_node_method_ping(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_ping(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_empty_response(shv_ctx, rid);
     return 0;
 }
 
-int shv_dotapp_node_method_date(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_date(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_error(shv_ctx, rid, SHV_RE_NOT_IMPLEMENTED, "shv-libs4c missing send date impl");

--- a/libs4c/libshvtree/shv_dotapp_node.c
+++ b/libs4c/libshvtree/shv_dotapp_node.c
@@ -18,21 +18,21 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int shv_dotapp_node_method_shvversionmajor(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_shvversionmajor(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 3);
     return 0;
 }
 
-int shv_dotapp_node_method_shvversionminor(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_shvversionminor(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 0);
     return 0;
 }
 
-int shv_dotapp_node_method_name(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_name(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -40,7 +40,7 @@ int shv_dotapp_node_method_name(shv_con_ctx_t *shv_ctx, shv_node_t *item, int ri
     return 0;
 }
 
-int shv_dotapp_node_method_version(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_version(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -48,14 +48,14 @@ int shv_dotapp_node_method_version(shv_con_ctx_t *shv_ctx, shv_node_t *item, int
     return 0;
 }
 
-int shv_dotapp_node_method_ping(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_ping(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_empty_response(shv_ctx, rid);
     return 0;
 }
 
-int shv_dotapp_node_method_date(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_date(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_error(shv_ctx, rid, SHV_RE_NOT_IMPLEMENTED, "shv-libs4c missing send date impl");

--- a/libs4c/libshvtree/shv_dotapp_node.c
+++ b/libs4c/libshvtree/shv_dotapp_node.c
@@ -62,7 +62,7 @@ int shv_dotapp_node_method_date(struct shv_con_ctx *shv_ctx, struct shv_node *it
     return 0;
 }
 
-const shv_method_des_t shv_dmap_item_dotapp_shvversionmajor =
+const struct shv_method_des shv_dmap_item_dotapp_shvversionmajor =
 {
     .name = "shvVersionMajor",
     .flags = SHV_METHOD_GETTER,
@@ -71,7 +71,7 @@ const shv_method_des_t shv_dmap_item_dotapp_shvversionmajor =
     .method = shv_dotapp_node_method_shvversionmajor
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_shvversionminor =
+const struct shv_method_des shv_dmap_item_dotapp_shvversionminor =
 {
     .name = "shvVersionMinor",
     .flags = SHV_METHOD_GETTER,
@@ -80,7 +80,7 @@ const shv_method_des_t shv_dmap_item_dotapp_shvversionminor =
     .method = shv_dotapp_node_method_shvversionminor
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_name =
+const struct shv_method_des shv_dmap_item_dotapp_name =
 {
     .name = "name",
     .flags = SHV_METHOD_GETTER,
@@ -89,7 +89,7 @@ const shv_method_des_t shv_dmap_item_dotapp_name =
     .method = shv_dotapp_node_method_name
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_version =
+const struct shv_method_des shv_dmap_item_dotapp_version =
 {
     .name = "version",
     .flags = SHV_METHOD_GETTER,
@@ -98,7 +98,7 @@ const shv_method_des_t shv_dmap_item_dotapp_version =
     .method = shv_dotapp_node_method_version
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_ping =
+const struct shv_method_des shv_dmap_item_dotapp_ping =
 {
     .name = "ping",
     .flags = 0,
@@ -107,7 +107,7 @@ const shv_method_des_t shv_dmap_item_dotapp_ping =
     .method = shv_dotapp_node_method_ping
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_date =
+const struct shv_method_des shv_dmap_item_dotapp_date =
 {
     .name = "date",
     .flags = 0,
@@ -116,7 +116,7 @@ const shv_method_des_t shv_dmap_item_dotapp_date =
     .method = shv_dotapp_node_method_date
 };
 
-static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
+static const struct shv_method_des *const shv_dmap_dotdevice_items[] =
 {
     &shv_dmap_item_dotapp_date,
     &shv_dmap_item_dir,

--- a/libs4c/libshvtree/shv_dotapp_node.c
+++ b/libs4c/libshvtree/shv_dotapp_node.c
@@ -34,7 +34,7 @@ int shv_dotapp_node_method_shvversionminor(struct shv_con_ctx *shv_ctx, struct s
 
 int shv_dotapp_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
+    struct shv_dotapp_node *appnode = UL_CONTAINEROF(item, struct shv_dotapp_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, appnode->name);
     return 0;
@@ -42,7 +42,7 @@ int shv_dotapp_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node *it
 
 int shv_dotapp_node_method_version(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
+    struct shv_dotapp_node *appnode = UL_CONTAINEROF(item, struct shv_dotapp_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, appnode->version);
     return 0;
@@ -131,9 +131,9 @@ static const struct shv_method_des *const shv_dmap_dotdevice_items[] =
 const struct shv_dmap shv_dotapp_dmap =
     SHV_CREATE_NODE_DMAP(dotapp, shv_dmap_dotdevice_items);
 
-shv_dotapp_node_t *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode)
+struct shv_dotapp_node *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode)
 {
-    shv_dotapp_node_t *item = calloc(1, sizeof(shv_dotapp_node_t));
+    struct shv_dotapp_node *item = calloc(1, sizeof(struct shv_dotapp_node));
     if (item == NULL) {
         perror(".app calloc");
         return NULL;

--- a/libs4c/libshvtree/shv_dotapp_node.c
+++ b/libs4c/libshvtree/shv_dotapp_node.c
@@ -128,10 +128,10 @@ static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
     &shv_dmap_item_dotapp_version
 };
 
-const shv_dmap_t shv_dotapp_dmap =
+const struct shv_dmap shv_dotapp_dmap =
     SHV_CREATE_NODE_DMAP(dotapp, shv_dmap_dotdevice_items);
 
-shv_dotapp_node_t *shv_tree_dotapp_node_new(const shv_dmap_t *dir, int mode)
+shv_dotapp_node_t *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode)
 {
     shv_dotapp_node_t *item = calloc(1, sizeof(shv_dotapp_node_t));
     if (item == NULL) {

--- a/libs4c/libshvtree/shv_dotdevice_node.c
+++ b/libs4c/libshvtree/shv_dotdevice_node.c
@@ -133,10 +133,10 @@ static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
     &shv_dmap_item_dotdevice_node_version
 };
 
-const shv_dmap_t shv_dotdevice_dmap =
+const struct shv_dmap shv_dotdevice_dmap =
     SHV_CREATE_NODE_DMAP(dotdevice, shv_dmap_dotdevice_items);
 
-shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const shv_dmap_t *dir, int mode)
+shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode)
 {
     shv_dotdevice_node_t *item = calloc(1, sizeof(shv_dotdevice_node_t));
     if (item == NULL) {

--- a/libs4c/libshvtree/shv_dotdevice_node.c
+++ b/libs4c/libshvtree/shv_dotdevice_node.c
@@ -23,13 +23,13 @@
     #include <nuttx/config.h>
 #endif
 
-static void shv_dotdevice_node_destructor(shv_node_t *node)
+static void shv_dotdevice_node_destructor(struct shv_node *node)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(node, shv_dotdevice_node_t, shv_node);
     free(devnode);
 }
 
-int shv_dotdevice_node_method_name(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -37,7 +37,7 @@ int shv_dotdevice_node_method_name(struct shv_con_ctx *shv_ctx, shv_node_t *item
     return 0;
 }
 
-int shv_dotdevice_node_method_version(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_version(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -45,7 +45,7 @@ int shv_dotdevice_node_method_version(struct shv_con_ctx *shv_ctx, shv_node_t *i
     return 0;
 }
 
-int shv_dotdevice_node_method_serial_number(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_serial_number(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -53,7 +53,7 @@ int shv_dotdevice_node_method_serial_number(struct shv_con_ctx *shv_ctx, shv_nod
     return 0;
 }
 
-int shv_dotdevice_node_method_reset(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_reset(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -69,7 +69,7 @@ int shv_dotdevice_node_method_reset(struct shv_con_ctx *shv_ctx, shv_node_t *ite
     return -1; /* How the hell did you get here?!! */
 }
 
-int shv_dotdevice_node_method_uptime(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_uptime(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);

--- a/libs4c/libshvtree/shv_dotdevice_node.c
+++ b/libs4c/libshvtree/shv_dotdevice_node.c
@@ -25,13 +25,13 @@
 
 static void shv_dotdevice_node_destructor(struct shv_node *node)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(node, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(node, struct shv_dotdevice_node, shv_node);
     free(devnode);
 }
 
 int shv_dotdevice_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, devnode->name);
     return 0;
@@ -39,7 +39,7 @@ int shv_dotdevice_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node 
 
 int shv_dotdevice_node_method_version(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, devnode->version);
     return 0;
@@ -47,7 +47,7 @@ int shv_dotdevice_node_method_version(struct shv_con_ctx *shv_ctx, struct shv_no
 
 int shv_dotdevice_node_method_serial_number(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, devnode->serial_number);
     return 0;
@@ -55,7 +55,7 @@ int shv_dotdevice_node_method_serial_number(struct shv_con_ctx *shv_ctx, struct 
 
 int shv_dotdevice_node_method_reset(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 0);
     /* Let the response bubble through the network stack */
@@ -71,7 +71,7 @@ int shv_dotdevice_node_method_reset(struct shv_con_ctx *shv_ctx, struct shv_node
 
 int shv_dotdevice_node_method_uptime(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, devnode->devops.uptime());
     return 0;
@@ -136,9 +136,9 @@ static const struct shv_method_des *const shv_dmap_dotdevice_items[] =
 const struct shv_dmap shv_dotdevice_dmap =
     SHV_CREATE_NODE_DMAP(dotdevice, shv_dmap_dotdevice_items);
 
-shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode)
+struct shv_dotdevice_node *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode)
 {
-    shv_dotdevice_node_t *item = calloc(1, sizeof(shv_dotdevice_node_t));
+    struct shv_dotdevice_node *item = calloc(1, sizeof(struct shv_dotdevice_node));
     if (item == NULL) {
         perror(".device calloc");
         return NULL;

--- a/libs4c/libshvtree/shv_dotdevice_node.c
+++ b/libs4c/libshvtree/shv_dotdevice_node.c
@@ -77,7 +77,7 @@ int shv_dotdevice_node_method_uptime(struct shv_con_ctx *shv_ctx, struct shv_nod
     return 0;
 }
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_name =
+const struct shv_method_des shv_dmap_item_dotdevice_node_name =
 {
     .name = "name",
     .flags = SHV_METHOD_GETTER,
@@ -86,7 +86,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_name =
     .method = shv_dotdevice_node_method_name
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_version =
+const struct shv_method_des shv_dmap_item_dotdevice_node_version =
 {
     .name = "version",
     .flags = SHV_METHOD_GETTER,
@@ -95,7 +95,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_version =
     .method = shv_dotdevice_node_method_version
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_serial_number =
+const struct shv_method_des shv_dmap_item_dotdevice_node_serial_number =
 {
     .name = "serialNumber",
     .flags = SHV_METHOD_GETTER,
@@ -104,7 +104,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_serial_number =
     .method = shv_dotdevice_node_method_serial_number
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_uptime =
+const struct shv_method_des shv_dmap_item_dotdevice_node_uptime =
 {
     .name = "uptime",
     .flags = SHV_METHOD_GETTER,
@@ -113,7 +113,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_uptime =
     .method = shv_dotdevice_node_method_uptime
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_reset =
+const struct shv_method_des shv_dmap_item_dotdevice_node_reset =
 {
     .name = "reset",
     .flags = 0,
@@ -122,7 +122,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_reset =
     .method = shv_dotdevice_node_method_reset
 };
 
-static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
+static const struct shv_method_des *const shv_dmap_dotdevice_items[] =
 {
     &shv_dmap_item_dir,
     &shv_dmap_item_ls,

--- a/libs4c/libshvtree/shv_dotdevice_node.c
+++ b/libs4c/libshvtree/shv_dotdevice_node.c
@@ -29,7 +29,7 @@ static void shv_dotdevice_node_destructor(shv_node_t *node)
     free(devnode);
 }
 
-int shv_dotdevice_node_method_name(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_name(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -37,7 +37,7 @@ int shv_dotdevice_node_method_name(shv_con_ctx_t *shv_ctx, shv_node_t *item, int
     return 0;
 }
 
-int shv_dotdevice_node_method_version(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_version(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -45,7 +45,7 @@ int shv_dotdevice_node_method_version(shv_con_ctx_t *shv_ctx, shv_node_t *item, 
     return 0;
 }
 
-int shv_dotdevice_node_method_serial_number(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_serial_number(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -53,7 +53,7 @@ int shv_dotdevice_node_method_serial_number(shv_con_ctx_t *shv_ctx, shv_node_t *
     return 0;
 }
 
-int shv_dotdevice_node_method_reset(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_reset(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -69,7 +69,7 @@ int shv_dotdevice_node_method_reset(shv_con_ctx_t *shv_ctx, shv_node_t *item, in
     return -1; /* How the hell did you get here?!! */
 }
 
-int shv_dotdevice_node_method_uptime(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_uptime(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);

--- a/libs4c/libshvtree/shv_file_node.c
+++ b/libs4c/libshvtree/shv_file_node.c
@@ -68,12 +68,12 @@ enum shv_file_node_keys
  */
 static void shv_file_node_destructor(shv_node_t *node)
 {
-  shv_file_node_t *file_node = UL_CONTAINEROF(node, shv_file_node_t, shv_node);
+  struct shv_file_node *file_node = UL_CONTAINEROF(node, struct shv_file_node, shv_node);
   free(file_node->fctx);
   free(&file_node->shv_node);
 }
 
-void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
+void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -124,7 +124,7 @@ void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *i
     }
 }
 
-void shv_file_send_size(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
+void shv_file_send_size(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -148,7 +148,7 @@ void shv_file_send_size(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *i
     }
 }
 
-int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
+int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     int ret;
     ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
@@ -291,7 +291,7 @@ int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t
  * If only the first number is passed (offset), CRC is calculated until the end of the file.
  * If both numbers are passed (offset and size), CRC is calcaulted over size bytes.
  */
-int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
+int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     int parse_result = -1;
     size_t size;
@@ -422,7 +422,7 @@ int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *
 int shv_file_node_write(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     int ret = 0;
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     ret = shv_file_process_write(shv_ctx, rid, file_node);
     if (ret < 0) {
         shv_send_error(shv_ctx, rid, SHV_RE_INVALID_PARAMS, "Garbled data");
@@ -438,7 +438,7 @@ int shv_file_node_write(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 int shv_file_node_crc(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     int ret;
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     ret = shv_file_process_crc(shv_ctx, rid, file_node);
     if (ret < 0) {
         shv_send_error(shv_ctx, rid, SHV_RE_INVALID_PARAMS, "Garbled data");
@@ -453,7 +453,7 @@ int shv_file_node_crc(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 
 int shv_file_node_size(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_uint(shv_ctx, rid, file_node->file_maxsize);
     return 0;
@@ -461,15 +461,16 @@ int shv_file_node_size(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 
 int shv_file_node_stat(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_file_send_stat(shv_ctx, rid, file_node);
     return 0;
 }
 
-shv_file_node_t *shv_tree_file_node_new(const char *child_name, const shv_dmap_t *dir, int mode)
+struct shv_file_node *shv_tree_file_node_new(const char *child_name, const shv_dmap_t *dir,
+                                             int mode)
 {
-    shv_file_node_t *item = calloc(1, sizeof(shv_file_node_t));
+    struct shv_file_node *item = calloc(1, sizeof(struct shv_file_node));
     if (item == NULL) {
         perror("file node calloc");
         return NULL;

--- a/libs4c/libshvtree/shv_file_node.c
+++ b/libs4c/libshvtree/shv_file_node.c
@@ -73,7 +73,7 @@ static void shv_file_node_destructor(shv_node_t *node)
   free(&file_node->shv_node);
 }
 
-void shv_file_send_stat(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -124,7 +124,7 @@ void shv_file_send_stat(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
     }
 }
 
-void shv_file_send_size(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+void shv_file_send_size(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -148,7 +148,7 @@ void shv_file_send_size(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
     }
 }
 
-int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
 {
     int ret;
     ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
@@ -291,7 +291,7 @@ int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *ite
  * If only the first number is passed (offset), CRC is calculated until the end of the file.
  * If both numbers are passed (offset and size), CRC is calcaulted over size bytes.
  */
-int shv_file_process_crc(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, shv_file_node_t *item)
 {
     int parse_result = -1;
     size_t size;
@@ -419,7 +419,7 @@ int shv_file_process_crc(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
     return -1;
 }
 
-int shv_file_node_write(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_write(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     int ret = 0;
     shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
@@ -435,7 +435,7 @@ int shv_file_node_write(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
     return 0;
 }
 
-int shv_file_node_crc(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_crc(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     int ret;
     shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
@@ -451,7 +451,7 @@ int shv_file_node_crc(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
     return ret;
 }
 
-int shv_file_node_size(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_size(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -459,7 +459,7 @@ int shv_file_node_size(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
     return 0;
 }
 
-int shv_file_node_stat(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_stat(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
 {
     shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);

--- a/libs4c/libshvtree/shv_file_node.c
+++ b/libs4c/libshvtree/shv_file_node.c
@@ -467,7 +467,7 @@ int shv_file_node_stat(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
     return 0;
 }
 
-struct shv_file_node *shv_tree_file_node_new(const char *child_name, const shv_dmap_t *dir,
+struct shv_file_node *shv_tree_file_node_new(const char *child_name, const struct shv_dmap *dir,
                                              int mode)
 {
     struct shv_file_node *item = calloc(1, sizeof(struct shv_file_node));
@@ -528,4 +528,4 @@ static const shv_method_des_t * const shv_file_node_dmap_items[] =
   &shv_dmap_item_file_node_write
 };
 
-const shv_dmap_t shv_file_node_dmap = SHV_CREATE_NODE_DMAP(file_node, shv_file_node_dmap_items);
+const struct shv_dmap shv_file_node_dmap = SHV_CREATE_NODE_DMAP(file_node, shv_file_node_dmap_items);

--- a/libs4c/libshvtree/shv_file_node.c
+++ b/libs4c/libshvtree/shv_file_node.c
@@ -66,7 +66,7 @@ enum shv_file_node_keys
  *
  * @param node
  */
-static void shv_file_node_destructor(shv_node_t *node)
+static void shv_file_node_destructor(struct shv_node *node)
 {
   struct shv_file_node *file_node = UL_CONTAINEROF(node, struct shv_file_node, shv_node);
   free(file_node->fctx);
@@ -419,7 +419,7 @@ int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_n
     return -1;
 }
 
-int shv_file_node_write(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_write(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     int ret = 0;
     struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
@@ -435,7 +435,7 @@ int shv_file_node_write(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
     return 0;
 }
 
-int shv_file_node_crc(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_crc(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     int ret;
     struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
@@ -451,7 +451,7 @@ int shv_file_node_crc(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
     return ret;
 }
 
-int shv_file_node_size(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_size(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
@@ -459,7 +459,7 @@ int shv_file_node_size(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
     return 0;
 }
 
-int shv_file_node_stat(struct shv_con_ctx *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_stat(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);

--- a/libs4c/libshvtree/shv_file_node.c
+++ b/libs4c/libshvtree/shv_file_node.c
@@ -494,31 +494,31 @@ struct shv_file_node *shv_tree_file_node_new(const char *child_name, const struc
     return item;
 }
 
-const shv_method_des_t shv_dmap_item_file_node_crc =
+const struct shv_method_des shv_dmap_item_file_node_crc =
 {
     .name = "crc",
     .method = shv_file_node_crc
 };
 
-const shv_method_des_t shv_dmap_item_file_node_write =
+const struct shv_method_des shv_dmap_item_file_node_write =
 {
     .name = "write",
     .method = shv_file_node_write
 };
 
-const shv_method_des_t shv_dmap_item_file_node_stat =
+const struct shv_method_des shv_dmap_item_file_node_stat =
 {
     .name = "stat",
     .method = shv_file_node_stat
 };
 
-const shv_method_des_t shv_dmap_item_file_node_size =
+const struct shv_method_des shv_dmap_item_file_node_size =
 {
     .name = "size",
     .method = shv_file_node_size
 };
 
-static const shv_method_des_t * const shv_file_node_dmap_items[] =
+static const struct shv_method_des * const shv_file_node_dmap_items[] =
 {
   &shv_dmap_item_file_node_crc,
   &shv_dmap_item_dir,

--- a/libs4c/libshvtree/shv_methods.c
+++ b/libs4c/libshvtree/shv_methods.c
@@ -82,20 +82,20 @@ const shv_method_des_t * const shv_root_dmap_items[] = {
   &shv_dmap_item_ls,
 };
 
-const shv_dmap_t shv_double_dmap = {.methods = {.items = (void **)shv_double_dmap_items,
+const struct shv_dmap shv_double_dmap = {.methods = {.items = (void **)shv_double_dmap_items,
                                                 .count = sizeof(shv_double_dmap_items)/sizeof(shv_double_dmap_items[0]),
                                                 .alloc_count = 0,
                                                }};
-const shv_dmap_t shv_double_read_only_dmap = {.methods = {.items = (void **)shv_double_read_only_dmap_items,
+const struct shv_dmap shv_double_read_only_dmap = {.methods = {.items = (void **)shv_double_read_only_dmap_items,
                                               .count = sizeof(shv_double_read_only_dmap_items)/sizeof(shv_double_read_only_dmap_items[0]),
                                               .alloc_count = 0,
                                               }};
-const shv_dmap_t shv_dir_ls_dmap = {.methods = {.items = (void **)shv_dir_ls_dmap_items,
+const struct shv_dmap shv_dir_ls_dmap = {.methods = {.items = (void **)shv_dir_ls_dmap_items,
                                                 .count = sizeof(shv_dir_ls_dmap_items)/sizeof(shv_dir_ls_dmap_items[0]),
                                                 .alloc_count = 0,
                                                }};
 
-const shv_dmap_t shv_root_dmap = {.methods = {.items = (void **)shv_root_dmap_items,
+const struct shv_dmap shv_root_dmap = {.methods = {.items = (void **)shv_root_dmap_items,
                                               .count = sizeof(shv_root_dmap_items)/sizeof(shv_root_dmap_items[0]),
                                               .alloc_count = 0,
                                              }};

--- a/libs4c/libshvtree/shv_methods.c
+++ b/libs4c/libshvtree/shv_methods.c
@@ -179,7 +179,7 @@ int shv_type(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
 
-  shv_node_typed_val_t *item_node = UL_CONTAINEROF(item, shv_node_typed_val_t,
+  struct shv_node_typed_val *item_node = UL_CONTAINEROF(item, struct shv_node_typed_val,
                                                    shv_node);
 
   str = item_node->type_name;
@@ -203,7 +203,7 @@ int shv_double_set(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, &shv_received);
 
-  shv_node_typed_val_t *item_node = UL_CONTAINEROF(item, shv_node_typed_val_t,
+  struct shv_node_typed_val *item_node = UL_CONTAINEROF(item, struct shv_node_typed_val,
                                                    shv_node);
 
   *(double *)item_node->val_ptr = shv_received;
@@ -228,7 +228,7 @@ int shv_double_get(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
 
-  shv_node_typed_val_t *item_node = UL_CONTAINEROF(item, shv_node_typed_val_t,
+  struct shv_node_typed_val *item_node = UL_CONTAINEROF(item, struct shv_node_typed_val,
                                                    shv_node);
 
   shv_send = *(double *)item_node->val_ptr;

--- a/libs4c/libshvtree/shv_methods.c
+++ b/libs4c/libshvtree/shv_methods.c
@@ -108,7 +108,7 @@ const shv_dmap_t shv_root_dmap = {.methods = {.items = (void **)shv_root_dmap_it
  *
  ****************************************************************************/
 
-int shv_ls(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_ls(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
 {
   int count;
   shv_node_list_names_it_t names_it;
@@ -138,7 +138,7 @@ int shv_ls(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_dir(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_dir(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
 {
   int met_num;
   int i;
@@ -173,7 +173,7 @@ int shv_dir(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_type(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_type(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
 {
   const char *str;
 
@@ -197,7 +197,7 @@ int shv_type(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_double_set(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_double_set(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
 {
   double shv_received;
 
@@ -222,7 +222,7 @@ int shv_double_set(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_double_get(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_double_get(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
 {
   double shv_send;
 

--- a/libs4c/libshvtree/shv_methods.c
+++ b/libs4c/libshvtree/shv_methods.c
@@ -111,7 +111,7 @@ const struct shv_dmap shv_root_dmap = {.methods = {.items = (void **)shv_root_dm
 int shv_ls(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   int count;
-  shv_node_list_names_it_t names_it;
+  struct shv_node_list_names_it names_it;
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
 

--- a/libs4c/libshvtree/shv_methods.c
+++ b/libs4c/libshvtree/shv_methods.c
@@ -108,7 +108,7 @@ const struct shv_dmap shv_root_dmap = {.methods = {.items = (void **)shv_root_dm
  *
  ****************************************************************************/
 
-int shv_ls(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
+int shv_ls(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   int count;
   shv_node_list_names_it_t names_it;
@@ -138,7 +138,7 @@ int shv_ls(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_dir(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
+int shv_dir(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   int met_num;
   int i;
@@ -173,7 +173,7 @@ int shv_dir(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_type(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
+int shv_type(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   const char *str;
 
@@ -197,7 +197,7 @@ int shv_type(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_double_set(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
+int shv_double_set(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   double shv_received;
 
@@ -222,7 +222,7 @@ int shv_double_set(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_double_get(struct shv_con_ctx * shv_ctx, shv_node_t* item, int rid)
+int shv_double_get(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   double shv_send;
 

--- a/libs4c/libshvtree/shv_methods.c
+++ b/libs4c/libshvtree/shv_methods.c
@@ -19,12 +19,12 @@
 
 /* Method descriptors - general methods "ls" and "dir" */
 
-const shv_method_des_t shv_dmap_item_ls = {
+const struct shv_method_des shv_dmap_item_ls = {
   .name = "ls",
   .access = SHV_ACCESS_BROWSE,
   .method = shv_ls
 };
-const shv_method_des_t shv_dmap_item_dir = {
+const struct shv_method_des shv_dmap_item_dir = {
   .name = "dir",
   .access = SHV_ACCESS_BROWSE,
   .method = shv_dir
@@ -32,7 +32,7 @@ const shv_method_des_t shv_dmap_item_dir = {
 
 /* Method descriptors - methods for parameters */
 
-const shv_method_des_t shv_dmap_item_type = {
+const struct shv_method_des shv_dmap_item_type = {
   .name = "typeName",
   .flags = SHV_METHOD_GETTER,
   .result = "s",
@@ -42,14 +42,14 @@ const shv_method_des_t shv_dmap_item_type = {
 
 /* Method descriptors - methods for double values: params and inputs/outputs */
 
-const shv_method_des_t shv_double_dmap_item_get = {
+const struct shv_method_des shv_double_dmap_item_get = {
   .name = "get",
   .flags = SHV_METHOD_GETTER,
   .result = "d",
   .access = SHV_ACCESS_READ,
   .method = shv_double_get
 };
-const shv_method_des_t shv_double_dmap_item_set = {
+const struct shv_method_des shv_double_dmap_item_set = {
   .name = "set",
   .flags = SHV_METHOD_SETTER,
   .param = "d|f",
@@ -57,7 +57,7 @@ const shv_method_des_t shv_double_dmap_item_set = {
   .method = shv_double_set
 };
 
-const shv_method_des_t * const shv_double_dmap_items[] = {
+const struct shv_method_des * const shv_double_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_double_dmap_item_get,
   &shv_dmap_item_ls,
@@ -65,19 +65,19 @@ const shv_method_des_t * const shv_double_dmap_items[] = {
   &shv_dmap_item_type,
 };
 
-const shv_method_des_t * const shv_double_read_only_dmap_items[] = {
+const struct shv_method_des * const shv_double_read_only_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_double_dmap_item_get,
   &shv_dmap_item_ls,
   &shv_dmap_item_type,
 };
 
-const shv_method_des_t * const shv_dir_ls_dmap_items[] = {
+const struct shv_method_des * const shv_dir_ls_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_dmap_item_ls,
 };
 
-const shv_method_des_t * const shv_root_dmap_items[] = {
+const struct shv_method_des * const shv_root_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_dmap_item_ls,
 };

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -25,10 +25,10 @@
 
 /* Custom tree implementation */
 
-GAVL_CUST_NODE_INT_IMP(shv_node_list_gavl, shv_node_list_t, shv_node_t,
+GAVL_CUST_NODE_INT_IMP(shv_node_list_gavl, struct shv_node_list, shv_node_t,
                        shv_node_list_key_t, list.gavl.root, gavl_node,
                        name, shv_node_list_comp_func)
-GSA_CUST_IMP(shv_node_list_gsa, shv_node_list_t, shv_node_t,
+GSA_CUST_IMP(shv_node_list_gsa, struct shv_node_list, shv_node_t,
                        shv_node_list_key_t, list.gsa.root,
                        name, shv_node_list_comp_func, 0)
 
@@ -132,7 +132,7 @@ void shv_node_list_it_reset(shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-void shv_node_list_it_init(shv_node_list_t *list, shv_node_list_it_t *it)
+void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it)
 {
   it->node_list = list;
   shv_node_list_it_reset(it);
@@ -204,7 +204,7 @@ static const char *shv_node_list_names_get_next(struct shv_str_list_it *it,
  *
  ****************************************************************************/
 
-void shv_node_list_names_it_init(shv_node_list_t *list,
+void shv_node_list_names_it_init(struct shv_node_list *list,
                                  shv_node_list_names_it_t *names_it)
 {
   shv_node_list_it_init(list, &names_it->list_it);

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -32,7 +32,7 @@ GSA_CUST_IMP(shv_node_list_gsa, struct shv_node_list, shv_node_t,
                        shv_node_list_key_t, list.gsa.root,
                        name, shv_node_list_comp_func, 0)
 
-GSA_CUST_IMP(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
+GSA_CUST_IMP(shv_dmap, struct shv_dmap, shv_method_des_t, shv_method_des_key_t,
 	           methods, name, shv_method_des_comp_func, 0)
 
 /**
@@ -242,10 +242,10 @@ void shv_tree_add_child(shv_node_t *node, shv_node_t *child)
  ****************************************************************************/
 
 void shv_tree_node_init(shv_node_t *item, const char *child_name,
-                        const shv_dmap_t *dir, int mode)
+                        const struct shv_dmap *dir, int mode)
 {
   item->name = child_name;
-  item->dir = UL_CAST_UNQ1(shv_dmap_t *, dir);
+  item->dir = UL_CAST_UNQ1(struct shv_dmap *, dir);
 
   item->children.mode = mode;
 
@@ -261,7 +261,7 @@ void shv_tree_node_init(shv_node_t *item, const char *child_name,
 }
 
 shv_node_t *shv_tree_node_new(const char *child_name,
-                              const shv_dmap_t *dir, int mode)
+                              const struct shv_dmap *dir, int mode)
 {
     shv_node_t *item = calloc(1, sizeof(shv_node_t));
     if (item == NULL) {
@@ -274,7 +274,7 @@ shv_node_t *shv_tree_node_new(const char *child_name,
 }
 
 shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name,
-                                                  const shv_dmap_t *dir,
+                                                  const struct shv_dmap *dir,
                                                   int mode)
 {
     shv_node_typed_val_t *item = calloc(1, sizeof(shv_node_typed_val_t));

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -46,13 +46,13 @@ static void shv_node_destructor(struct shv_node *node)
 }
 
 /**
- * @brief Destructor for shv_node_typed_val_t
+ * @brief Destructor for struct shv_node_typed_val
  *
  * @param node
  */
 static void shv_typed_val_node_destructor(struct shv_node *node)
 {
-  shv_node_typed_val_t *typed_node = UL_CONTAINEROF(node, shv_node_typed_val_t, shv_node);
+  struct shv_node_typed_val *typed_node = UL_CONTAINEROF(node, struct shv_node_typed_val, shv_node);
   free(typed_node);
 }
 
@@ -273,11 +273,11 @@ struct shv_node *shv_tree_node_new(const char *child_name,
     return item;
 }
 
-shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name,
+struct shv_node_typed_val *shv_tree_node_typed_val_new(const char *child_name,
                                                   const struct shv_dmap *dir,
                                                   int mode)
 {
-    shv_node_typed_val_t *item = calloc(1, sizeof(shv_node_typed_val_t));
+    struct shv_node_typed_val *item = calloc(1, sizeof(struct shv_node_typed_val));
     if (item == NULL) {
         printf("typed_val node calloc");
         return NULL;

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -174,10 +174,10 @@ struct shv_node *shv_node_list_it_next(shv_node_list_it_t *it)
 static const char *shv_node_list_names_get_next(struct shv_str_list_it *it,
                                                 int reset_to_first)
 {
-  shv_node_list_names_it_t *names_it;
+  struct shv_node_list_names_it *names_it;
   struct shv_node *node;
 
-  names_it = UL_CONTAINEROF(it, shv_node_list_names_it_t, str_it);
+  names_it = UL_CONTAINEROF(it, struct shv_node_list_names_it, str_it);
 
   if (reset_to_first)
     {
@@ -205,7 +205,7 @@ static const char *shv_node_list_names_get_next(struct shv_str_list_it *it,
  ****************************************************************************/
 
 void shv_node_list_names_it_init(struct shv_node_list *list,
-                                 shv_node_list_names_it_t *names_it)
+                                 struct shv_node_list_names_it *names_it)
 {
   shv_node_list_it_init(list, &names_it->list_it);
   names_it->str_it.get_next_entry = shv_node_list_names_get_next;

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -171,7 +171,7 @@ shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-static const char *shv_node_list_names_get_next(shv_str_list_it_t *it,
+static const char *shv_node_list_names_get_next(struct shv_str_list_it *it,
                                                 int reset_to_first)
 {
   shv_node_list_names_it_t *names_it;

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -112,7 +112,7 @@ struct shv_node *shv_node_find(struct shv_node *node, const char * path)
  *
  ****************************************************************************/
 
-void shv_node_list_it_reset(shv_node_list_it_t *it)
+void shv_node_list_it_reset(struct shv_node_list_it *it)
 {
   if (it->node_list->mode & SHV_NLIST_MODE_GSA)
     {
@@ -132,7 +132,7 @@ void shv_node_list_it_reset(shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it)
+void shv_node_list_it_init(struct shv_node_list *list, struct shv_node_list_it *it)
 {
   it->node_list = list;
   shv_node_list_it_reset(it);
@@ -146,7 +146,7 @@ void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-struct shv_node *shv_node_list_it_next(shv_node_list_it_t *it)
+struct shv_node *shv_node_list_it_next(struct shv_node_list_it *it)
 {
   struct shv_node *node;
 

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -32,7 +32,7 @@ GSA_CUST_IMP(shv_node_list_gsa, struct shv_node_list, struct shv_node,
                        shv_node_list_key_t, list.gsa.root,
                        name, shv_node_list_comp_func, 0)
 
-GSA_CUST_IMP(shv_dmap, struct shv_dmap, shv_method_des_t, shv_method_des_key_t,
+GSA_CUST_IMP(shv_dmap, struct shv_dmap, struct shv_method_des, shv_method_des_key_t,
 	           methods, name, shv_method_des_comp_func, 0)
 
 /**
@@ -339,7 +339,7 @@ int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char *met,
     }
 
     /* Call coresponding method */
-    const shv_method_des_t *met_des = shv_dmap_find(item->dir, &met);
+    const struct shv_method_des *met_des = shv_dmap_find(item->dir, &met);
     if (met_des == NULL) {
         shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
         snprintf(error_msg, sizeof(error_msg), "Method '%.40s' does not exist.", met);

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -25,10 +25,10 @@
 
 /* Custom tree implementation */
 
-GAVL_CUST_NODE_INT_IMP(shv_node_list_gavl, struct shv_node_list, shv_node_t,
+GAVL_CUST_NODE_INT_IMP(shv_node_list_gavl, struct shv_node_list, struct shv_node,
                        shv_node_list_key_t, list.gavl.root, gavl_node,
                        name, shv_node_list_comp_func)
-GSA_CUST_IMP(shv_node_list_gsa, struct shv_node_list, shv_node_t,
+GSA_CUST_IMP(shv_node_list_gsa, struct shv_node_list, struct shv_node,
                        shv_node_list_key_t, list.gsa.root,
                        name, shv_node_list_comp_func, 0)
 
@@ -40,7 +40,7 @@ GSA_CUST_IMP(shv_dmap, struct shv_dmap, shv_method_des_t, shv_method_des_key_t,
  *
  * @param node
  */
-static void shv_node_destructor(shv_node_t *node)
+static void shv_node_destructor(struct shv_node *node)
 {
   free(node);
 }
@@ -50,7 +50,7 @@ static void shv_node_destructor(shv_node_t *node)
  *
  * @param node
  */
-static void shv_typed_val_node_destructor(shv_node_t *node)
+static void shv_typed_val_node_destructor(struct shv_node *node)
 {
   shv_node_typed_val_t *typed_node = UL_CONTAINEROF(node, shv_node_typed_val_t, shv_node);
   free(typed_node);
@@ -64,7 +64,7 @@ static void shv_typed_val_node_destructor(shv_node_t *node)
  *
  ****************************************************************************/
 
-shv_node_t *shv_node_find(shv_node_t *node, const char * path)
+struct shv_node *shv_node_find(struct shv_node *node, const char * path)
 {
   if (strlen(path) == 0)
     {
@@ -146,9 +146,9 @@ void shv_node_list_it_init(struct shv_node_list *list, shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it)
+struct shv_node *shv_node_list_it_next(shv_node_list_it_t *it)
 {
-  shv_node_t *node;
+  struct shv_node *node;
 
   if (it->node_list->mode & SHV_NLIST_MODE_GSA)
     {
@@ -175,7 +175,7 @@ static const char *shv_node_list_names_get_next(struct shv_str_list_it *it,
                                                 int reset_to_first)
 {
   shv_node_list_names_it_t *names_it;
-  shv_node_t *node;
+  struct shv_node *node;
 
   names_it = UL_CONTAINEROF(it, shv_node_list_names_it_t, str_it);
 
@@ -219,7 +219,7 @@ void shv_node_list_names_it_init(struct shv_node_list *list,
  *
  ****************************************************************************/
 
-void shv_tree_add_child(shv_node_t *node, shv_node_t *child)
+void shv_tree_add_child(struct shv_node *node, struct shv_node *child)
 {
   if (node->children.mode & SHV_NLIST_MODE_GSA)
     {
@@ -237,11 +237,11 @@ void shv_tree_add_child(shv_node_t *node, shv_node_t *child)
  * Name: shv_tree_node_init
  *
  * Description:
- *   Initialize the shv_node_t node.
+ *   Initialize the struct shv_node node.
  *
  ****************************************************************************/
 
-void shv_tree_node_init(shv_node_t *item, const char *child_name,
+void shv_tree_node_init(struct shv_node *item, const char *child_name,
                         const struct shv_dmap *dir, int mode)
 {
   item->name = child_name;
@@ -260,10 +260,10 @@ void shv_tree_node_init(shv_node_t *item, const char *child_name,
     }
 }
 
-shv_node_t *shv_tree_node_new(const char *child_name,
+struct shv_node *shv_tree_node_new(const char *child_name,
                               const struct shv_dmap *dir, int mode)
 {
-    shv_node_t *item = calloc(1, sizeof(shv_node_t));
+    struct shv_node *item = calloc(1, sizeof(struct shv_node));
     if (item == NULL) {
         perror("node calloc");
         return NULL;
@@ -295,9 +295,9 @@ shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name,
  *
  ****************************************************************************/
 
-void shv_tree_destroy(shv_node_t *parent)
+void shv_tree_destroy(struct shv_node *parent)
 {
-    shv_node_t *child;
+    struct shv_node *child;
 
     if (parent->children.mode & SHV_NLIST_MODE_GSA) {
         gsa_cust_for_each_cut(shv_node_list_gsa, &parent->children, child) {
@@ -330,7 +330,7 @@ int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char *met,
     char error_msg[80];
 
     /* Find the node */
-    shv_node_t *item = shv_node_find(shv_ctx->root, path);
+    struct shv_node *item = shv_node_find(shv_ctx->root, path);
     if (item == NULL) {
         shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
         snprintf(error_msg, sizeof(error_msg), "Node '%.40s' does not exist.", path);

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -323,7 +323,7 @@ void shv_tree_destroy(shv_node_t *parent)
  *
  ****************************************************************************/
 
-int shv_node_process(shv_con_ctx_t *shv_ctx, int rid, const char *met,
+int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char *met,
                      const char *path)
 {
     /* If the node or method names are too long, the printed lengths is limited */


### PR DESCRIPTION
All typedefs of structs changed to plain structs. I'm keeping the libshvchainpack library the same, this applies only to libshvtree.

Closes #7