### PR TITLE
shv_com.h: use array designators for error strings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodule/ulut"]
-	path = submodule/ulut
-	url = https://git.code.sf.net/p/ulan/ulut.git

--- a/Makefile.omk
+++ b/Makefile.omk
@@ -1,4 +1,4 @@
-SUBDIRS = submodule/ulut libs4c
+SUBDIRS = libs4c
 
 #nobase_include_HEADERS =
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -5,7 +5,7 @@
 #  (C) Copyright 2006, 2007, 2008, 2009, 2010, 2011, 2013, 2015 by Michal Sojka - Czech Technical University, FEE, DCE
 #
 #  Homepage: http://rtime.felk.cvut.cz/omk/
-#  Version:  0.2-196-g89918a2
+#  Version:  0.2-217-g2a676f5
 #
 # The OMK build system is distributed under the GNU General Public
 # License.  See file COPYING for details.
@@ -411,7 +411,7 @@ define cp_cmd
 if ! cmp -s $(1) $(2); then \
     echo "  CP      $(1:$(OUTPUT_DIR)/%=%) -> $(2:$(OUTPUT_DIR)/%=%)"; \
     install -d $(CPHEADER_FLAGS) `dirname $(2)` && \
-    install $(CPHEADER_FLAGS) $(1) $(2) || exit 1; \
+    install -m 0644 $(CPHEADER_FLAGS) $(1) $(2) || exit 1; \
 fi
 endef
 else
@@ -444,6 +444,13 @@ include-pass-local-$(2): $$($(2)_GEN_HEADERS) $$(foreach f,$$(renamed_$(2)_GEN_H
 	@$$(if $$($(2)_HEADERS)$$($(2)_GEN_HEADERS)$$(nobase_$(2)_HEADERS)$$(renamed_$(2)_HEADERS)$$(renamed_$(2)_GEN_HEADERS),,true)
 endef
                                                                                  #OMK:linux.omk@Makefile.rules.linux
+# Output variables:
+# OBJ_EXT - extension of object files
+# LIB_EXT - extension of library files
+# SOLIB_EXT - extension of dynamically linked libraries
+# LIB_PREF - prefix for library files
+# ASM_EXT - extension of assembler sources
+
 BUILD_DIR_NAME = _build
 COMPILED_DIR_NAME = _compiled
 ifndef GROUP_DIR_NAME
@@ -495,6 +502,11 @@ else
   SOLIB_EXT = so
   SOLIB_PICFLAGS += -fpic
 endif
+
+OBJ_EXT = .o
+LIB_EXT = .a
+LIB_PREF = lib
+ASM_EXT = .S
 
 #vpath %.c $(SOURCES_DIR)
 #vpath %.cc $(SOURCES_DIR)
@@ -653,7 +665,7 @@ $(2)/$(1)$(3): $(TARGET_OBJS)
 	$(Q) $(if $(filter $(CXX_PATTERN),$(TARGET_SOURCES)),$$(CXX),$$(CC)) \
 	  $(TARGET_OBJS) $$($(1)_LIBS:%=-l%) $$(LOADLIBES) $$(OMK_LDFLAGS) $$(LDFLAGS) $$($(1)_LDFLAGS) -Wl,-rpath-link,$(USER_LIB_DIR) -Wl,-Map,$(USER_OBJS_DIR)/$(1).exe.map -o $$@
 	@echo "$(2)/$(1)$(3): \\" >$(USER_OBJS_DIR)/$(1).exe.d
-	@$(SED4OMK) -n -e 's|^LOAD \(.*\)$$$$|  \1  \&|p' $(USER_OBJS_DIR)/$(1).exe.map|tr '&' '\134'  >>$(USER_OBJS_DIR)/$(1).exe.d
+	@$(SED4OMK) -n -e 's|^LOAD \(.*\)$$$$|  \1  \&|p' $(USER_OBJS_DIR)/$(1).exe.map|tr '&' '\134' | grep -v '^  linker [^ ]'  >>$(USER_OBJS_DIR)/$(1).exe.d
 	@echo >>$(USER_OBJS_DIR)/$(1).exe.d
 
 binary-pass-local: $(2)/$(1)$(3)
@@ -684,6 +696,17 @@ $(USER_LIB_DIR)/lib$(1).a: $(TARGET_OBJS)
 	$(Q) $(AR) rcs $$@ $$^
 
 library-pass-local: $(USER_LIB_DIR)/lib$(1).a
+
+.PHONY: $(OMK_WORK_DIR)/lib$(1).a.omkvar
+$(OMK_WORK_DIR)/lib$(1).a.omkvar:
+	$(Q)echo '$(1)_objsar += $$$$(addprefix $(USER_OBJS_DIR)/,$(TARGET_OBJS))' > $$@.tmp; \
+	    echo 'static_libs := $$$$(sort $(1) $$$$(static_libs))' >> $$@.tmp; \
+	    if cmp -s $$@.tmp $$@; then rm $$@.tmp; else mv $$@.tmp $$@; fi
+
+library-pass-local: $(OMK_WORK_DIR)/lib$(1).a.omkvar
+ifeq ($(EXPORT_LIB_OBJS_EARLY),y)
+include-pass-local: $(OMK_WORK_DIR)/lib$(1).a.omkvar
+endif
 endef
 
 
@@ -858,6 +881,11 @@ cc_o_kern_COMPILE = $(KERN_CC) $(kernel_INCLUDES) -idirafter $(kern_GCCLIB_DIR)/
 S_o_kern_COMPILE = $(KERN_CC) $(kernel_INCLUDES) -idirafter $(kern_GCCLIB_DIR)/include $(LINUX_CPPFLAGS) $(LINUX_AFLAGS) $(LINUX_AFLAGS_MODULE) -DOMK_FOR_KERNEL -DEXPORT_SYMTAB -nostdinc
 KERN_EXE_SUFFIX := $(LINUX_MODULE_EXT)
 KERN_LDFLAGS = $(LINUX_LDFLAGS) $(LINUX_LDFLAGS_MODULE)
+ifeq ($(wildcard $(LINUX_DIR)/scripts/module.lds),)
+KERN_LDSCRIPT=
+else
+KERN_LDSCRIPT=$(LINUX_DIR)/scripts/module.lds
+endif
 ifdef LINUX_ARCH
 KERN_ARCH = $(LINUX_ARCH)
 else
@@ -912,12 +940,13 @@ endif
 
 ifeq ($(LINUX_CONFIG_MODVERSIONS),y)
 MODPOST_OPTS += -m
+endif
 MODPOST_OPTS += -i $(LINUX_DIR)/Module.symvers
-ifneq ($(LINUX_BUILDHOST),) # this is not correct point, it should look for 2.6.17 kernel
-MODPOST_OPTS += -I $(KERN_LIB_DIR)/Module.symvers
-endif
+# there has been -I flag from 2.6.17 to 5.3.x kernels
+# to read external modules symbols
+#   MODPOST_OPTS += -I $(KERN_LIB_DIR)/Module.symvers
+# but it is replaced by option to specify -i multiple times
 MODPOST_OPTS += -o $(KERN_LIB_DIR)/Module.symvers
-endif
 
 ifeq ($(LINUX_CONFIG_DEBUG_SECTION_MISMATCH),y)
 MODPOST_OPTS += -S
@@ -1022,7 +1051,7 @@ $(2)/$(1)$(KERN_LINK_SUFFIX): $$($(1)_OBJS)
 	@$(QUIET_CMD_ECHO) "  LD [K]  $$@"
 	$(Q) $$(KERN_LD) $$(KERN_LDFLAGS) -r $$($(1)_OBJS) -L$$(kern_GCCLIB_DIR) $$($(1)_LIBS:%=-l%) $$(KERN_LOADLIBES) -Map $(KERN_OBJS_DIR)/$(1).mod.map -o $$@
 	@echo "$(2)/$(1)$(KERN_LINK_SUFFIX): \\" >$(KERN_OBJS_DIR)/$(1).mod.d
-	@$(SED4OMK) -n -e 's/^LOAD \(.*\)$$$$/  \1  \\/p' $(KERN_OBJS_DIR)/$(1).mod.map  >>$(KERN_OBJS_DIR)/$(1).mod.d
+	@$(SED4OMK) -n -e 's/^LOAD \(.*\)$$$$/  \1  \\/p' $(KERN_OBJS_DIR)/$(1).mod.map | grep -v '^  linker [^ ]' >>$(KERN_OBJS_DIR)/$(1).mod.d
 	@echo >>$(KERN_OBJS_DIR)/$(1).mod.d
 	@if [ "$(KERN_EXE_SUFFIX)" = ".ko" ] ; then \
 	  echo $(1) >>$(KERN_MODPOST_DIR)/module-changes ; \
@@ -1085,13 +1114,15 @@ $(2) : $(1)$(KERN_LINK_SUFFIX) $(1).mod.c
 	$(Q) $$(c_o_kern_COMPILE) -D"KBUILD_BASENAME=$(KERN_MQ)$(1)$(KERN_MQ)" \
 		-D"KBUILD_MODNAME=$(KERN_MQ)$(1)$(KERN_MQ)" \
 		-o $(1).mod.o -c $(1).mod.c
-	$(Q) $$(KERN_LD) $$(KERN_LDFLAGS) $(1)$(KERN_LINK_SUFFIX) $(1).mod.o -r -o $$@
+	$(Q) $$(KERN_LD) $$(KERN_LDFLAGS) $(1)$(KERN_LINK_SUFFIX) $(1).mod.o -r $$(KERN_LDSCRIPT:%=-T %) -o $$@
 endef
 
 kernel-modpost-versions: $(wildcard $(LINUX_DIR)/Module.symvers)
 	@$(QUIET_CMD_ECHO) "  MODPOST    $(KERN_MODPOST_DIR)"
 	@echo  >$(KERN_MODPOST_DIR)/modpost-running
 	@rm -f $(KERN_MODPOST_DIR)/module-changes
+	@for mod in $(MODULES_LIST) ; do echo "$$mod$(KERN_LINK_SUFFIX)" >"$(KERN_MODPOST_DIR)/$$mod.mod" ; done
+	@for mod in $(MODULES_LIST) ; do touch "$(KERN_MODPOST_DIR)/.$$mod$(KERN_LINK_SUFFIX).cmd" ; done
 	$(Q) $(KERN_MODPOST) $(MODPOST_OPTS) $(MODULES_LIST:%=%$(KERN_LINK_SUFFIX))
 
 $(MODULES_LIST:%=%.mod.c) : kernel-modpost-versions
@@ -1203,9 +1234,9 @@ library-pass-local: $(addprefix $(USER_INCLUDE_DIR)/,$(cmetric_include_HEADERS))
 
 $(foreach cmetrh,$(cmetric_include_HEADERS),$(eval $(call COMPILE_c_o_template,\
 		$(SOURCES_DIR)/$($(basename $(notdir $(cmetrh)))_CMETRIC_SOURCES),\
-		$($(basename $(notdir $(cmetrh)))_CMETRIC_SOURCES:%.c=%.o),)))
+		$($(basename $(notdir $(cmetrh)))_CMETRIC_SOURCES:%.c=%$(OBJ_EXT)),)))
 $(foreach cmetrh,$(cmetric_include_HEADERS),$(eval $(call CMETRIC_o_h_template,\
-		$($(basename $(notdir $(cmetrh)))_CMETRIC_SOURCES:%.c=%.o),\
+		$($(basename $(notdir $(cmetrh)))_CMETRIC_SOURCES:%.c=%$(OBJ_EXT)),\
 		$(addprefix $(USER_INCLUDE_DIR)/,$(cmetrh)))))
 
 GEN_HEADERS+=$(cmetric_include_HEADERS:%=$(USER_INCLUDE_DIR)/%)
@@ -1371,7 +1402,7 @@ sources-list-pass-local:
 	@$(foreach h,$(renamed_include_HEADERS),echo '$(h)'|$(SED4OMK) -e 's|\(.*\)->.*|$(addsuffix /,$(RELATIVE_DIR:$(SOURCES_LIST_DIR)/%=%))\1|' >> "$(SOURCES_LIST).tmp";)
 	@$(foreach bin,$(lib_LIBRARIES) $(shared_LIBRARIES) $(bin_PROGRAMS) $(test_PROGRAMS) $(utils_PROGRAMS) \
 	  $(kernel_LIBRARIES) $(rtlinux_LIBRARIES) $(kernel_MODULES),\
-	  $(foreach src,$(filter-out %.o,$($(bin)_SOURCES)),echo "$(addsuffix /,$(RELATIVE_DIR:$(SOURCES_LIST_DIR)/%=%))$(src)" >> "$(SOURCES_LIST).tmp";))
+	  $(foreach src,$(filter-out %$(OBJ_EXT),$($(bin)_SOURCES)),echo "$(addsuffix /,$(RELATIVE_DIR:$(SOURCES_LIST_DIR)/%=%))$(src)" >> "$(SOURCES_LIST).tmp";))
 
 ############ TAGS ###########
 

--- a/libs4c/libshvtree/include/shv/tree/shv_clayer_posix.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_clayer_posix.h
@@ -20,8 +20,9 @@
 
 #define SHV_FILE_POSIX_BITFLAG_OPENED ((uint32_t)(1 << 0)) /* File already opened flag */
 
-typedef struct shv_dotdevice_node shv_dotdevice_node_t;
-typedef struct shv_file_node shv_file_node_t;
+/* Forward declarations */
+struct shv_dotdevice_node;
+struct shv_file_node;
 struct shv_connection;
 
 struct shv_file_node_fctx
@@ -63,7 +64,7 @@ struct shv_thrd_ctx
  * @param item
  * @return int
  */
-int shv_file_node_posix_opener(shv_file_node_t *item);
+int shv_file_node_posix_opener(struct shv_file_node *item);
 
 /**
  * @brief POSIX shv_file_node_getsize implementation
@@ -71,7 +72,7 @@ int shv_file_node_posix_opener(shv_file_node_t *item);
  * @param item
  * @return int
  */
-int shv_file_node_posix_getsize(shv_file_node_t *item);
+int shv_file_node_posix_getsize(struct shv_file_node *item);
 
 /**
  * @brief POSIX shv_file_node_writer implementation
@@ -81,7 +82,7 @@ int shv_file_node_posix_getsize(shv_file_node_t *item);
  * @param count
  * @return int
  */
-int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count);
+int shv_file_node_posix_writer(struct shv_file_node *item, void *buf, size_t count);
 
 /**
  * @brief POSIX shv_file_node_seeker implementation
@@ -90,7 +91,7 @@ int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count);
  * @param offset
  * @return int
  */
-int shv_file_node_posix_seeker(shv_file_node_t *item, int offset);
+int shv_file_node_posix_seeker(struct shv_file_node *item, int offset);
 
 /**
  * @brief POSIX shv_file_node_reader implementation
@@ -100,7 +101,7 @@ int shv_file_node_posix_seeker(shv_file_node_t *item, int offset);
  * @param count
  * @return int
  */
-int shv_file_node_posix_reader(shv_file_node_t *item, void *buf, size_t count);
+int shv_file_node_posix_reader(struct shv_file_node *item, void *buf, size_t count);
 
 /**
  * @brief POSIX shv_file_node_crc32 implementation
@@ -111,7 +112,7 @@ int shv_file_node_posix_reader(shv_file_node_t *item, void *buf, size_t count);
  * @param result
  * @return int
  */
-int shv_file_node_posix_crc32(shv_file_node_t *item, int start, size_t size, uint32_t *result);
+int shv_file_node_posix_crc32(struct shv_file_node *item, int start, size_t size, uint32_t *result);
 
 /**
  * @brief POSIX shv_dotdevice_node_uptime implementation

--- a/libs4c/libshvtree/include/shv/tree/shv_com.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_com.h
@@ -175,7 +175,9 @@ int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d);
 /**
  * @brief Platform dependant function. Creates the communication processing thread.
  *
- * @param priority
+ * @param thrd_prio an int number that specifies the priority on the platform level,
+ *                  if you wish the OS to default to normal thread priorities and policy,
+ *                  set thrd_prio to -1
  * @return int 0 on success, -1 on failure
  */
 int shv_create_process_thread(int thrd_prio, struct shv_con_ctx *ctx);

--- a/libs4c/libshvtree/include/shv/tree/shv_com.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_com.h
@@ -66,16 +66,16 @@ enum shv_con_errno
     SHV_ERRNOS_COUNT
 };
 
-static const char *shv_con_errno_strs[SHV_ERRNOS_COUNT] =
+static const char *shv_con_errno_strs[] =
 {
-    "",
-    "Process thread creation fail",
-    "Tlayer init fail",
-    "Read from tlayer fail",
-    "Too many reconnects",
-    "Login to broker fail",
-    "Error in chainpack packing",
-    "Error in chainpack unpacking"
+    [SHV_NO_ERROR] = "",
+    [SHV_PROC_THRD] = "Process thread creation fail",
+    [SHV_TLAYER_INIT] = "Tlayer init fail",
+    [SHV_TLAYER_READ] = "Read from tlayer fail",
+    [SHV_RECONNECTS] = "Too many reconnects",
+    [SHV_LOGIN] = "Login to broker fail",
+    [SHV_CCPCP_PACK] =  "Error in chainpack packing",
+    [SHV_CCPCP_UNPACK] = "Error in chainpack unpacking"
 };
 
 /**

--- a/libs4c/libshvtree/include/shv/tree/shv_com.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_com.h
@@ -85,20 +85,20 @@ static const char *shv_con_errno_strs[SHV_ERRNOS_COUNT] =
 enum shv_attention_reason
 {
     SHV_ATTENTION_ERROR,        /* A nonrecoverable error occured, you should inspect
-                                   `err_no` in shv_con_ctx_t */
+                                   `err_no` in struct shv_con_ctx */
     SHV_ATTENTION_CONNECTED,    /* The thread succesfully connected to a broker */
     SHV_ATTENTION_DISCONNECTED, /* The connection was closed by the remote host */
     SHV_ATTENTION_COUNT
 };
 
 /* Forward declaration */
-typedef struct shv_con_ctx shv_con_ctx_t;
+struct shv_con_ctx;
 
 /**
  * @brief An attention signaller used to signal the application
  *        of some events
  */
-typedef void (*shv_attention_signaller)(shv_con_ctx_t *shv_ctx,
+typedef void (*shv_attention_signaller)(struct shv_con_ctx *shv_ctx,
                                         enum shv_attention_reason r);
 
 /* Forward declaration */
@@ -108,28 +108,29 @@ struct shv_node;
  * @brief Main SHV Communication context.
  *
  */
-typedef struct shv_con_ctx {
-  int stream_fd;
-  int timeout;
-  int rid;
-  int cid_cnt;
-  int cid_capacity;
-  int *cid_ptr;
-  enum shv_con_errno err_no;
-  struct ccpcp_pack_context pack_ctx;
-  struct ccpcp_unpack_context unpack_ctx;
-  char shv_data[SHV_BUF_LEN];
-  char shv_rd_data[SHV_BUF_LEN];
-  int write_err;
-  int shv_len;
-  int shv_send;
-  int reconnects;
-  atomic_bool running;
-  struct shv_thrd_ctx thrd_ctx;
-  struct shv_node *root;
-  struct shv_connection *connection;            /* Transport layer information */
-  shv_attention_signaller at_signlr;            /* A user defined attention signaller callback */
-} shv_con_ctx_t;
+struct shv_con_ctx
+{
+    int stream_fd;
+    int timeout;
+    int rid;
+    int cid_cnt;
+    int cid_capacity;
+    int *cid_ptr;
+    enum shv_con_errno err_no;
+    struct ccpcp_pack_context pack_ctx;
+    struct ccpcp_unpack_context unpack_ctx;
+    char shv_data[SHV_BUF_LEN];
+    char shv_rd_data[SHV_BUF_LEN];
+    int write_err;
+    int shv_len;
+    int shv_send;
+    int reconnects;
+    atomic_bool running;
+    struct shv_thrd_ctx thrd_ctx;
+    struct shv_node *root;
+    struct shv_connection *connection;            /* Transport layer information */
+    shv_attention_signaller at_signlr;            /* A user defined attention signaller callback */
+};
 
 struct shv_dir_res {
   const char *name;
@@ -139,10 +140,11 @@ struct shv_dir_res {
   int access;
 };
 
-typedef struct shv_str_list_it_t shv_str_list_it_t;
+/* Forward declaration */
+struct shv_str_list_it;
 
-struct shv_str_list_it_t {
-   const char * (*get_next_entry)(shv_str_list_it_t *it, int reset_to_first);
+struct shv_str_list_it {
+   const char * (*get_next_entry)(struct shv_str_list_it *it, int reset_to_first);
 };
 
 /**
@@ -151,22 +153,22 @@ struct shv_str_list_it_t {
  * @param ctx
  * @return const char*
  */
-static inline const char *shv_errno_str(shv_con_ctx_t *ctx)
+static inline const char *shv_errno_str(struct shv_con_ctx *ctx)
 {
     return shv_con_errno_strs[ctx->err_no];
 }
 
-void shv_send_int(shv_con_ctx_t *shv_ctx, int rid, int num);
-void shv_send_uint(shv_con_ctx_t *shv_ctx, int rid, unsigned int num);
-void shv_send_double(shv_con_ctx_t *shv_ctx, int rid, double num);
-void shv_send_str(shv_con_ctx_t *shv_ctx, int rid, const char *str);
-void shv_send_str_list(shv_con_ctx_t *shv_ctx, int rid, int num_str, const char **str);
-void shv_send_str_list_it(shv_con_ctx_t *shv_ctx, int rid, int num_str, shv_str_list_it_t *str_it);
-void shv_send_dir(shv_con_ctx_t *shv_ctx, const struct shv_dir_res *results, int cnt, int rid);
-void shv_send_error(shv_con_ctx_t *shv_ctx, int rid, enum shv_response_error_code code,
+void shv_send_int(struct shv_con_ctx *shv_ctx, int rid, int num);
+void shv_send_uint(struct shv_con_ctx *shv_ctx, int rid, unsigned int num);
+void shv_send_double(struct shv_con_ctx *shv_ctx, int rid, double num);
+void shv_send_str(struct shv_con_ctx *shv_ctx, int rid, const char *str);
+void shv_send_str_list(struct shv_con_ctx *shv_ctx, int rid, int num_str, const char **str);
+void shv_send_str_list_it(struct shv_con_ctx *shv_ctx, int rid, int num_str, struct shv_str_list_it *str_it);
+void shv_send_dir(struct shv_con_ctx *shv_ctx, const struct shv_dir_res *results, int cnt, int rid);
+void shv_send_error(struct shv_con_ctx *shv_ctx, int rid, enum shv_response_error_code code,
                     const char *msg);
-void shv_send_ping(shv_con_ctx_t *shv_ctx);
-void shv_send_empty_response(shv_con_ctx_t *shv_ctx, int rid);
+void shv_send_ping(struct shv_con_ctx *shv_ctx);
+void shv_send_empty_response(struct shv_con_ctx *shv_ctx, int rid);
 
 int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d);
 
@@ -176,14 +178,14 @@ int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d);
  * @param priority
  * @return int 0 on success, -1 on failure
  */
-int shv_create_process_thread(int thrd_prio, shv_con_ctx_t *ctx);
+int shv_create_process_thread(int thrd_prio, struct shv_con_ctx *ctx);
 
 /**
  * @brief Platform dependant function. Stops the communication processing thread.
  *
  * @param shv_ctx
  */
-void shv_stop_process_thread(shv_con_ctx_t *shv_ctx);
+void shv_stop_process_thread(struct shv_con_ctx *shv_ctx);
 
 /**
  * @brief Allocate and initialize a shv_com_ctx_t struct.
@@ -193,7 +195,7 @@ void shv_stop_process_thread(shv_con_ctx_t *shv_ctx);
  * @param at_signlr
  * @return nonNULL pointer on success, NULL on failure
  */
-shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *con_info,
+struct shv_con_ctx *shv_com_init(struct shv_node *root, struct shv_connection *con_info,
                             shv_attention_signaller at_signlr);
 
 /**
@@ -201,7 +203,7 @@ shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *con_in
  *
  * @param shv_ctx
  */
-void shv_com_destroy(shv_con_ctx_t *shv_ctx);
+void shv_com_destroy(struct shv_con_ctx *shv_ctx);
 
 /**
  * @brief Launched in a separate thread, this function handles the connection to the broker.
@@ -212,4 +214,4 @@ void shv_com_destroy(shv_con_ctx_t *shv_ctx);
  * @param shv_ctx
  * @return 0 on success, -1 on failure
  */
-int shv_process(shv_con_ctx_t *shv_ctx);
+int shv_process(struct shv_con_ctx *shv_ctx);

--- a/libs4c/libshvtree/include/shv/tree/shv_com_common.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_com_common.h
@@ -14,7 +14,7 @@
 #include <stddef.h>
 #include <shv/chainpack/ccpcp.h>
 
-typedef struct shv_con_ctx shv_con_ctx_t;
+struct shv_con_ctx;
 
 /**
  * @brief A handler responsible for the sending of data
@@ -39,7 +39,7 @@ size_t shv_underrflow_handler(struct ccpcp_unpack_context * ctx);
  * @param shv_ctx
  * @param rid
  */
-void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid);
+void shv_pack_head_reply(struct shv_con_ctx *shv_ctx, int rid);
 
 /**
  * @brief Discard data of arbitrary type (container, string, blob).
@@ -48,4 +48,4 @@ void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid);
  * @param shv_ctx
  * @return 0 in case of success, -1 in case of failure
  */
-int shv_unpack_discard(shv_con_ctx_t * shv_ctx);
+int shv_unpack_discard(struct shv_con_ctx * shv_ctx);

--- a/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotapp_node.h
@@ -19,28 +19,29 @@
  */
 typedef int (*shv_dotapp_node_date)(void);
 
-typedef struct shv_dotapp_node {
-    shv_node_t shv_node;           /* Base shv_node */
+struct shv_dotapp_node
+{
+    struct shv_node shv_node;      /* Base shv_node */
     struct {
         shv_dotapp_node_date date; /* Date function callback */
     } appops;
 
     const char *name;              /* Application's name */
     const char *version;           /* Application's version */
-} shv_dotapp_node_t;
+};
 
-extern const shv_method_des_t shv_dmap_item_dotapp_shvversionmajor;
-extern const shv_method_des_t shv_dmap_item_dotapp_shvversionminor;
-extern const shv_method_des_t shv_dmap_item_dotapp_name;
-extern const shv_method_des_t shv_dmap_item_dotapp_version;
-extern const shv_method_des_t shv_dmap_item_dotapp_ping;
-extern const shv_method_des_t shv_dmap_item_dotapp_date;
+extern const struct shv_method_des shv_dmap_item_dotapp_shvversionmajor;
+extern const struct shv_method_des shv_dmap_item_dotapp_shvversionminor;
+extern const struct shv_method_des shv_dmap_item_dotapp_name;
+extern const struct shv_method_des shv_dmap_item_dotapp_version;
+extern const struct shv_method_des shv_dmap_item_dotapp_ping;
+extern const struct shv_method_des shv_dmap_item_dotapp_date;
 
 /**
  * @brief The dotapp method structure.
  *
  */
-extern const shv_dmap_t shv_dotapp_dmap;
+extern const struct shv_dmap shv_dotapp_dmap;
 
 /**
  * @brief Allocate a new standard .app node
@@ -49,4 +50,4 @@ extern const shv_dmap_t shv_dotapp_dmap;
  * @param mode
  * @return non NULL reference on success, NULL otherwise
  */
-shv_dotapp_node_t *shv_tree_dotapp_node_new(const shv_dmap_t *dir, int mode);
+struct shv_dotapp_node *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_dotdevice_node.h
@@ -14,7 +14,7 @@
 #include "shv_tree.h"
 
 /* Forward declaration */
-typedef struct shv_dotdevice_node shv_dotdevice_node_t;
+struct shv_dotdevice_node;
 
 /**
  * @brief A platform dependant function used to track time.
@@ -28,8 +28,9 @@ typedef int (*shv_dotdevice_node_uptime)(void);
  */
 typedef int (*shv_dotdevice_node_reset)(void);
 
-typedef struct shv_dotdevice_node {
-    shv_node_t shv_node;                  /* Base shv_node */
+struct shv_dotdevice_node
+{
+    struct shv_node shv_node;             /* Base shv_node */
     struct {
         shv_dotdevice_node_reset  reset;  /* Platform dependant reset function */
         shv_dotdevice_node_uptime uptime; /* Platform dependant uptime function */
@@ -38,19 +39,19 @@ typedef struct shv_dotdevice_node {
     const char *name;                     /* */
     const char *serial_number;
     const char *version;
-} shv_dotdevice_node_t;
+};
 
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_name;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_version;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_serial_number;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_uptime;
-extern const shv_method_des_t shv_dmap_item_dotdevice_node_reset;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_name;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_version;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_serial_number;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_uptime;
+extern const struct shv_method_des shv_dmap_item_dotdevice_node_reset;
 
 /**
  * @brief The dotdevice method structure.
  * 
  */
-extern const shv_dmap_t shv_dotdevice_dmap;
+extern const struct shv_dmap shv_dotdevice_dmap;
 
 /**
  * @brief Allocate a new standard .dotdevice node
@@ -59,4 +60,4 @@ extern const shv_dmap_t shv_dotdevice_dmap;
  * @param mode 
  * @return non NULL reference on success, NULL otherwise
  */
-shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const shv_dmap_t *dir, int mode);
+struct shv_dotdevice_node *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/include/shv/tree/shv_methods.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_methods.h
@@ -28,16 +28,16 @@
 #define SHV_ACCESS_WRITE   ((int)16)
 #define SHV_ACCESS_COMMAND ((int)24)
 
-extern const shv_method_des_t shv_dmap_item_ls;
-extern const shv_method_des_t shv_dmap_item_dir;
+extern const struct shv_method_des shv_dmap_item_ls;
+extern const struct shv_method_des shv_dmap_item_dir;
 
-extern const shv_dmap_t shv_double_dmap;
-extern const shv_dmap_t shv_double_read_only_dmap;
-extern const shv_dmap_t shv_dir_ls_dmap;
-extern const shv_dmap_t shv_root_dmap;
+extern const struct shv_dmap shv_double_dmap;
+extern const struct shv_dmap shv_double_read_only_dmap;
+extern const struct shv_dmap shv_dir_ls_dmap;
+extern const struct shv_dmap shv_root_dmap;
 
-int shv_ls(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_dir(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_type(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_double_get(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
-int shv_double_set(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid);
+int shv_ls(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_dir(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_type(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_double_get(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);
+int shv_double_set(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid);

--- a/libs4c/libshvtree/include/shv/tree/shv_tree.h
+++ b/libs4c/libshvtree/include/shv/tree/shv_tree.h
@@ -38,7 +38,8 @@
         }\
     }
 
-typedef struct shv_node_list {
+struct shv_node_list
+{
   int mode;                         /* Mode selection (GAVL vs GSA, static vs dynamic) */
   union {
     struct {
@@ -49,40 +50,43 @@ typedef struct shv_node_list {
       gsa_array_field_t root;       /* GSA root */
     } gsa;
   } list;
-} shv_node_list_t;
+};
 
-typedef struct shv_dmap {
+struct shv_dmap {
   gsa_array_field_t methods;  /* GSA array of methods */
-} shv_dmap_t;
+};
 
-typedef struct shv_node shv_node_t;
-typedef struct shv_node {
+struct shv_node;
+struct shv_node
+{
   struct {
-    void (*destructor)(shv_node_t *this);
-  } vtable;                 /* Node vtable */
-  const char *name;         /* Node name */
-  gavl_node_t gavl_node;    /* GAVL instance */
-  shv_dmap_t *dir;          /* Pointer to supported methods */
-  shv_node_list_t children; /* List of node children */
-} shv_node_t;
+    void (*destructor)(struct shv_node *this);
+  } vtable;                      /* Node vtable */
+  const char *name;              /* Node name */
+  gavl_node_t gavl_node;         /* GAVL instance */
+  struct shv_dmap *dir;          /* Pointer to supported methods */
+  struct shv_node_list children; /* List of node children */
+};
 
-typedef struct shv_node_typed_val {
-  shv_node_t shv_node;          /* Node instance */
+struct shv_node_typed_val
+{
+  struct shv_node shv_node;     /* Node instance */
   void *val_ptr;                /* Double value */
   char *type_name;              /* Type of the value (int, double...) */
-} shv_node_typed_val_t;
+};
 
-typedef struct shv_con_ctx shv_con_ctx_t;
-typedef int (* shv_method_t) (shv_con_ctx_t *ctx, shv_node_t * node, int rid);
+struct shv_con_ctx;
+typedef int (* shv_method_t) (struct shv_con_ctx *ctx, struct shv_node * node, int rid);
 
-typedef struct shv_method_des {
+struct shv_method_des
+{
   const char *name;       /* Method name */
   const int flags;        /* Method flags */
   const char *param;      /* Parameter type for request */
   const char *result;     /* Result type for responses */
   const int access;       /* Access level */
   shv_method_t method;    /* Pointer to the method function */
-} shv_method_des_t;
+};
 
 typedef const char *shv_node_list_key_t;
 typedef const char *shv_method_des_key_t;
@@ -91,10 +95,10 @@ typedef const char *shv_method_des_key_t;
 /* GAVL_CUST_NODE_INT_DEC - standard custom tree with internal node */
 /* GAVL_FLES_INT_DEC      - tree with enhanced first last access speed  */
 
-GAVL_CUST_NODE_INT_DEC(shv_node_list_gavl, shv_node_list_t, shv_node_t, shv_node_list_key_t,
+GAVL_CUST_NODE_INT_DEC(shv_node_list_gavl, struct shv_node_list, struct shv_node, shv_node_list_key_t,
 	list.gavl.root, gavl_node, name, shv_node_list_comp_func)
 
-GSA_CUST_DEC(shv_node_list_gsa, shv_node_list_t, shv_node_t, shv_node_list_key_t,
+GSA_CUST_DEC(shv_node_list_gsa, struct shv_node_list, struct shv_node, shv_node_list_key_t,
 	list.gsa.root, name, shv_node_list_comp_func)
 
 static inline int
@@ -109,23 +113,24 @@ shv_method_des_comp_func(const shv_method_des_key_t *a, const shv_method_des_key
   return strcmp(*a, *b);
 }
 
-GSA_CUST_DEC(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
+GSA_CUST_DEC(shv_dmap, struct shv_dmap, struct shv_method_des, shv_method_des_key_t,
 	methods, name, shv_method_des_comp_func)
 
-typedef struct shv_node_list_it_t {
-  shv_node_list_t *node_list;
+struct shv_node_list_it
+{
+  struct shv_node_list *node_list;
   union {
-    shv_node_t *gavl_next_node;
+    struct shv_node *gavl_next_node;
     int gsa_next_indx;
   } list_it;
-} shv_node_list_it_t;
+};
 
-void shv_node_list_it_init(shv_node_list_t *list, shv_node_list_it_t *it);
-void shv_node_list_it_reset(shv_node_list_it_t *it);
-shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it);
+void shv_node_list_it_init(struct shv_node_list *list, struct shv_node_list_it *it);
+void shv_node_list_it_reset(struct shv_node_list_it *it);
+struct shv_node *shv_node_list_it_next(struct shv_node_list_it *it);
 
 static inline int
-shv_node_list_count(shv_node_list_t *node_list)
+shv_node_list_count(struct shv_node_list *node_list)
 {
   if (node_list->mode & SHV_NLIST_MODE_GSA)
     {
@@ -137,26 +142,27 @@ shv_node_list_count(shv_node_list_t *node_list)
     }
 }
 
-typedef struct shv_node_list_names_it_t {
-  shv_str_list_it_t str_it;
-  shv_node_list_it_t list_it;
-} shv_node_list_names_it_t;
+struct shv_node_list_names_it
+{
+  struct shv_str_list_it str_it;
+  struct shv_node_list_it list_it;
+};
 
-void shv_node_list_names_it_init(shv_node_list_t *list, shv_node_list_names_it_t *names_it);
+void shv_node_list_names_it_init(struct shv_node_list *list, struct shv_node_list_names_it *names_it);
 
 /* Public functions definition */
 
-int shv_node_process(shv_con_ctx_t *shv_ctx, int rid, const char * met, const char * path);
-shv_node_t *shv_node_find(shv_node_t *node, const char * path);
-void shv_tree_add_child(shv_node_t *node, shv_node_t *child);
-void shv_tree_node_init(shv_node_t *item, const char *child_name, const shv_dmap_t *dir, int mode);
+int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char * met, const char * path);
+struct shv_node *shv_node_find(struct shv_node *node, const char * path);
+void shv_tree_add_child(struct shv_node *node, struct shv_node *child);
+void shv_tree_node_init(struct shv_node *item, const char *child_name, const struct shv_dmap *dir, int mode);
 
 /**
  * @brief Destroy the whole SHV tree, given the parent node
  *
  * @param parent
  */
-void shv_tree_destroy(shv_node_t *parent);
+void shv_tree_destroy(struct shv_node *parent);
 
 /**
  * @brief Allocates and initializes a simple node
@@ -166,14 +172,14 @@ void shv_tree_destroy(shv_node_t *parent);
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-shv_node_t *shv_tree_node_new(const char *child_name, const shv_dmap_t *dir, int mode);
+struct shv_node *shv_tree_node_new(const char *child_name, const struct shv_dmap *dir, int mode);
 
 /**
- * @brief Initialize the shv_node_typed_val_t node
+ * @brief Initialize the struct shv_node_typed_val node
  *
  * @param child_name
  * @param dir
  * @param mode
  * @return A nonNULL pointer on success, NULL otherwise
  */
-shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name, const shv_dmap_t *dir, int mode);
+struct shv_node_typed_val *shv_tree_node_typed_val_new(const char *child_name, const struct shv_dmap *dir, int mode);

--- a/libs4c/libshvtree/shv_clayer_posix.c
+++ b/libs4c/libshvtree/shv_clayer_posix.c
@@ -404,6 +404,7 @@ int shv_create_process_thread(int thrd_prio, struct shv_con_ctx *ctx)
     int ret;
     int policy;
     pthread_attr_t attr;
+    pthread_attr_t *pattr;
     struct sched_param schparam;
 
     /* Create the pipe to the dataready function. The poll function is used but we expect
@@ -429,18 +430,23 @@ int shv_create_process_thread(int thrd_prio, struct shv_con_ctx *ctx)
         return -2;
     }
 
-    ret = pthread_attr_init(&attr);
-    RETLZ_ERROR(error);
-    ret = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
-    RETLZ_ERROR(error);
-    ret = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
-    RETLZ_ERROR(error);
-    ret = pthread_getschedparam(pthread_self(), &policy, &schparam);
-    RETLZ_ERROR(error);
-    schparam.sched_priority = thrd_prio;
-    ret = pthread_attr_setschedparam(&attr, &schparam);
-    RETLZ_ERROR(error);
-    ret = pthread_create(&ctx->thrd_ctx.id, &attr, __shv_process, (void *)ctx);
+    if (thrd_prio != -1) {
+        ret = pthread_attr_init(&attr);
+        RETLZ_ERROR(error);
+        ret = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+        RETLZ_ERROR(error);
+        ret = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+        RETLZ_ERROR(error);
+        ret = pthread_getschedparam(pthread_self(), &policy, &schparam);
+        RETLZ_ERROR(error);
+        schparam.sched_priority = thrd_prio;
+        ret = pthread_attr_setschedparam(&attr, &schparam);
+        RETLZ_ERROR(error);
+        pattr = &attr;
+    } else {
+        pattr = NULL;
+    }
+    ret = pthread_create(&ctx->thrd_ctx.id, pattr, __shv_process, (void *)ctx);
     RETLZ_ERROR(error);
     return ret;
 

--- a/libs4c/libshvtree/shv_clayer_posix.c
+++ b/libs4c/libshvtree/shv_clayer_posix.c
@@ -50,7 +50,7 @@
 #define RETLZ_ERROR(__err_label) if (ret < 0) goto __err_label
 #define CHUNK_SIZE ((size_t)64)
 
-int shv_file_node_posix_opener(shv_file_node_t *item)
+int shv_file_node_posix_opener(struct shv_file_node *item)
 {
     struct shv_file_node_fctx *fctx = (struct shv_file_node_fctx*) item->fctx;
     if (!(fctx->flags & SHV_FILE_POSIX_BITFLAG_OPENED)) {
@@ -64,7 +64,7 @@ int shv_file_node_posix_opener(shv_file_node_t *item)
     return 0;
 }
 
-int shv_file_node_posix_getsize(shv_file_node_t *item)
+int shv_file_node_posix_getsize(struct shv_file_node *item)
 {
     struct stat st;
     if (stat(item->name, &st) < 0) {
@@ -73,7 +73,7 @@ int shv_file_node_posix_getsize(shv_file_node_t *item)
     return st.st_size;
 }
 
-int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count)
+int shv_file_node_posix_writer(struct shv_file_node *item, void *buf, size_t count)
 {
     struct shv_file_node_fctx *fctx = (struct shv_file_node_fctx*) item->fctx;
 
@@ -90,7 +90,7 @@ int shv_file_node_posix_writer(shv_file_node_t *item, void *buf, size_t count)
     return -1;
 }
 
-int shv_file_node_posix_seeker(shv_file_node_t *item, int offset)
+int shv_file_node_posix_seeker(struct shv_file_node *item, int offset)
 {
     struct shv_file_node_fctx *fctx = (struct shv_file_node_fctx*) item->fctx;
 
@@ -104,7 +104,7 @@ int shv_file_node_posix_seeker(shv_file_node_t *item, int offset)
     return -1;
 }
 
-int shv_file_node_posix_crc32(shv_file_node_t *item, int start, size_t size, uint32_t *result)
+int shv_file_node_posix_crc32(struct shv_file_node *item, int start, size_t size, uint32_t *result)
 {
     /* The calculation between Linux and NuttX differs a bit. While both implementations
      * use the IEEE 802.3, the process is a bit different.
@@ -390,7 +390,7 @@ int shv_tcpip_posix_dataready(struct shv_connection *connection, int timeout)
 
 static void *__shv_process(void *arg)
 {
-    shv_con_ctx_t *shv_ctx = (shv_con_ctx_t *)arg;
+    struct shv_con_ctx *shv_ctx = (struct shv_con_ctx *)arg;
     shv_ctx->thrd_ctx.thrd_ret = shv_process(shv_ctx);
     /* Report a hard error */
     if (shv_ctx->thrd_ctx.thrd_ret == -1 && shv_ctx->at_signlr != NULL) {
@@ -399,7 +399,7 @@ static void *__shv_process(void *arg)
     return NULL;
 }
 
-int shv_create_process_thread(int thrd_prio, shv_con_ctx_t *ctx)
+int shv_create_process_thread(int thrd_prio, struct shv_con_ctx *ctx)
 {
     int ret;
     int policy;
@@ -449,7 +449,7 @@ error:
     return -1;
 }
 
-void shv_stop_process_thread(shv_con_ctx_t *shv_ctx)
+void shv_stop_process_thread(struct shv_con_ctx *shv_ctx)
 {
     /* Write to the pipe to simulate the instant timeout */
     /* The write is enclosed in {} to suppress warn_unused_result warning */

--- a/libs4c/libshvtree/shv_com.c
+++ b/libs4c/libshvtree/shv_com.c
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
-int cid_alloc(shv_con_ctx_t * shv_ctx)
+int cid_alloc(struct shv_con_ctx * shv_ctx)
 {
   if (shv_ctx->cid_capacity < shv_ctx->cid_cnt)
     {
@@ -74,7 +74,7 @@ int cid_alloc(shv_con_ctx_t * shv_ctx)
  *
  ****************************************************************************/
 
-void shv_pack_head_request(shv_con_ctx_t *shv_ctx, char *met, char *path)
+void shv_pack_head_request(struct shv_con_ctx *shv_ctx, char *met, char *path)
 {
   cchainpack_pack_meta_begin(&shv_ctx->pack_ctx);
 
@@ -101,7 +101,7 @@ void shv_pack_head_request(shv_con_ctx_t *shv_ctx, char *met, char *path)
  *
  ****************************************************************************/
 
-int shv_unpack_head(shv_con_ctx_t * shv_ctx, int * rid, char * method,
+int shv_unpack_head(struct shv_con_ctx * shv_ctx, int * rid, char * method,
                     char * path)
 {
   int i;
@@ -365,7 +365,7 @@ int shv_unpack_data(ccpcp_unpack_context * ctx, int * v, double * d)
  *
  ****************************************************************************/
 
-int shv_process_input(shv_con_ctx_t * shv_ctx)
+int shv_process_input(struct shv_con_ctx * shv_ctx)
 {
   int i;
   int j;
@@ -415,7 +415,7 @@ int shv_process_input(shv_con_ctx_t * shv_ctx)
  *
  ****************************************************************************/
 
-void shv_send_ping(shv_con_ctx_t *shv_ctx)
+void shv_send_ping(struct shv_con_ctx *shv_ctx)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx, shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -447,7 +447,7 @@ void shv_send_ping(shv_con_ctx_t *shv_ctx)
  *
  ****************************************************************************/
 
-void shv_send_int(shv_con_ctx_t *shv_ctx, int rid, int num)
+void shv_send_int(struct shv_con_ctx *shv_ctx, int rid, int num)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx, shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -472,7 +472,7 @@ void shv_send_int(shv_con_ctx_t *shv_ctx, int rid, int num)
     }
 }
 
-void shv_send_uint(shv_con_ctx_t *shv_ctx, int rid, unsigned int num)
+void shv_send_uint(struct shv_con_ctx *shv_ctx, int rid, unsigned int num)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx, shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -505,7 +505,7 @@ void shv_send_uint(shv_con_ctx_t *shv_ctx, int rid, unsigned int num)
  *
  ****************************************************************************/
 
-void shv_send_double(shv_con_ctx_t *shv_ctx, int rid, double num)
+void shv_send_double(struct shv_con_ctx *shv_ctx, int rid, double num)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data,
                           SHV_BUF_LEN,shv_overflow_handler);
@@ -538,7 +538,7 @@ void shv_send_double(shv_con_ctx_t *shv_ctx, int rid, double num)
  *
  ****************************************************************************/
 
-void shv_send_str(shv_con_ctx_t *shv_ctx, int rid, const char *str)
+void shv_send_str(struct shv_con_ctx *shv_ctx, int rid, const char *str)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -563,7 +563,7 @@ void shv_send_str(shv_con_ctx_t *shv_ctx, int rid, const char *str)
     }
 }
 
-void shv_send_empty_response(shv_con_ctx_t *shv_ctx, int rid)
+void shv_send_empty_response(struct shv_con_ctx *shv_ctx, int rid)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -594,7 +594,7 @@ void shv_send_empty_response(shv_con_ctx_t *shv_ctx, int rid)
  *
  ****************************************************************************/
 
-void shv_send_str_list(shv_con_ctx_t *shv_ctx, int rid, int num_str,
+void shv_send_str_list(struct shv_con_ctx *shv_ctx, int rid, int num_str,
                        const char **str)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
@@ -635,8 +635,8 @@ void shv_send_str_list(shv_con_ctx_t *shv_ctx, int rid, int num_str,
  *
  ****************************************************************************/
 
-void shv_send_str_list_it(shv_con_ctx_t *shv_ctx, int rid, int num_str,
-                          shv_str_list_it_t *str_it)
+void shv_send_str_list_it(struct shv_con_ctx *shv_ctx, int rid, int num_str,
+                          struct shv_str_list_it *str_it)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                           shv_overflow_handler);
@@ -697,7 +697,7 @@ void shv_send_str_list_it(shv_con_ctx_t *shv_ctx, int rid, int num_str,
  *
  ****************************************************************************/
 
-void shv_send_dir(shv_con_ctx_t *shv_ctx, const struct shv_dir_res *results,
+void shv_send_dir(struct shv_con_ctx *shv_ctx, const struct shv_dir_res *results,
                   int cnt, int rid)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
@@ -768,7 +768,7 @@ void shv_send_dir(shv_con_ctx_t *shv_ctx, const struct shv_dir_res *results,
  *
  ****************************************************************************/
 
-void shv_send_error(shv_con_ctx_t *shv_ctx, int rid, enum shv_response_error_code code,
+void shv_send_error(struct shv_con_ctx *shv_ctx, int rid, enum shv_response_error_code code,
                     const char *msg)
 {
   ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data,
@@ -814,7 +814,7 @@ void shv_send_error(shv_con_ctx_t *shv_ctx, int rid, enum shv_response_error_cod
  *
  ****************************************************************************/
 
-int shv_login(shv_con_ctx_t *shv_ctx)
+int shv_login(struct shv_con_ctx *shv_ctx)
 {
   int i;
   int id = 0;
@@ -1005,14 +1005,14 @@ int shv_login(shv_con_ctx_t *shv_ctx)
  * Name: shv_con_ctx_init
  *
  * Description:
- *   Fill the shv_con_ctx_t with variables.
+ *   Fill the struct shv_con_ctx with variables.
  *
  ****************************************************************************/
 
-void shv_con_ctx_init(shv_con_ctx_t *shv_ctx, struct shv_node *root,
+void shv_con_ctx_init(struct shv_con_ctx *shv_ctx, struct shv_node *root,
                       struct shv_connection *connection, shv_attention_signaller at_signlr)
 {
-  memset(shv_ctx, 0, sizeof(shv_con_ctx_t));
+  memset(shv_ctx, 0, sizeof(struct shv_con_ctx));
 
   shv_ctx->root = root;
   shv_ctx->timeout = 360;
@@ -1027,7 +1027,7 @@ void shv_con_ctx_init(shv_con_ctx_t *shv_ctx, struct shv_node *root,
  * @param shv_ctx
  * @return int
  */
-static inline int shv_process_communication(shv_con_ctx_t *shv_ctx)
+static inline int shv_process_communication(struct shv_con_ctx *shv_ctx)
 {
     int ret;
 
@@ -1072,7 +1072,7 @@ static inline int shv_process_communication(shv_con_ctx_t *shv_ctx)
     return ret;
 }
 
-int shv_process(shv_con_ctx_t *shv_ctx)
+int shv_process(struct shv_con_ctx *shv_ctx)
 {
     int ret;
     /* A local enum to keep track of the connection */
@@ -1177,10 +1177,10 @@ int shv_process(shv_con_ctx_t *shv_ctx)
  *
  ****************************************************************************/
 
-shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *connection,
+struct shv_con_ctx *shv_com_init(struct shv_node *root, struct shv_connection *connection,
                             shv_attention_signaller at_signlr)
 {
-  shv_con_ctx_t *shv_ctx = (shv_con_ctx_t *)malloc(sizeof(shv_con_ctx_t));
+  struct shv_con_ctx *shv_ctx = (struct shv_con_ctx *)malloc(sizeof(struct shv_con_ctx));
   if (shv_ctx == NULL)
     {
       printf("ERROR: Failed to allocate memory for shv_ctx\n");
@@ -1191,7 +1191,7 @@ shv_con_ctx_t *shv_com_init(struct shv_node *root, struct shv_connection *connec
   return shv_ctx;
 }
 
-void shv_com_destroy(shv_con_ctx_t *shv_ctx)
+void shv_com_destroy(struct shv_con_ctx *shv_ctx)
 {
     atomic_store(&shv_ctx->running, false);
     shv_tree_destroy(shv_ctx->root);

--- a/libs4c/libshvtree/shv_com_common.c
+++ b/libs4c/libshvtree/shv_com_common.c
@@ -23,7 +23,7 @@
 void shv_overflow_handler(struct ccpcp_pack_context *ctx, size_t size_hint)
 {
 
-  shv_con_ctx_t *shv_ctx = UL_CONTAINEROF(ctx, shv_con_ctx_t, pack_ctx);
+  struct shv_con_ctx *shv_ctx = UL_CONTAINEROF(ctx, struct shv_con_ctx, pack_ctx);
   size_t to_send = ctx->current - ctx->start;
   char * ptr_data = shv_ctx->shv_data;
   int ret = 0;
@@ -58,7 +58,7 @@ size_t shv_underrflow_handler(struct ccpcp_unpack_context * ctx)
 {
   int i;
 
-  shv_con_ctx_t *shv_ctx = UL_CONTAINEROF(ctx, shv_con_ctx_t, unpack_ctx);
+  struct shv_con_ctx *shv_ctx = UL_CONTAINEROF(ctx, struct shv_con_ctx, unpack_ctx);
 
   i = shv_ctx->connection->tops.read(shv_ctx->connection,
                                      shv_ctx->shv_rd_data, sizeof(shv_ctx->shv_rd_data));
@@ -72,7 +72,7 @@ size_t shv_underrflow_handler(struct ccpcp_unpack_context * ctx)
   return i;
 }
 
-void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid)
+void shv_pack_head_reply(struct shv_con_ctx *shv_ctx, int rid)
 {
   cchainpack_pack_meta_begin(&shv_ctx->pack_ctx);
 
@@ -108,7 +108,7 @@ void shv_pack_head_reply(shv_con_ctx_t *shv_ctx, int rid)
  * @param shv_ctx
  * @return 0 in case of success, -1 on failure
  */
-static int shv_unpack_contskip(shv_con_ctx_t *shv_ctx)
+static int shv_unpack_contskip(struct shv_con_ctx *shv_ctx)
 {
     struct ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
     int level = 1;
@@ -132,7 +132,7 @@ static int shv_unpack_contskip(shv_con_ctx_t *shv_ctx)
     return 0;
 }
 
-int shv_unpack_discard(shv_con_ctx_t * shv_ctx)
+int shv_unpack_discard(struct shv_con_ctx *shv_ctx)
 {
     struct ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
 

--- a/libs4c/libshvtree/shv_dotapp_node.c
+++ b/libs4c/libshvtree/shv_dotapp_node.c
@@ -18,51 +18,51 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int shv_dotapp_node_method_shvversionmajor(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_shvversionmajor(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 3);
     return 0;
 }
 
-int shv_dotapp_node_method_shvversionminor(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_shvversionminor(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 0);
     return 0;
 }
 
-int shv_dotapp_node_method_name(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
+    struct shv_dotapp_node *appnode = UL_CONTAINEROF(item, struct shv_dotapp_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, appnode->name);
     return 0;
 }
 
-int shv_dotapp_node_method_version(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_version(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotapp_node_t *appnode = UL_CONTAINEROF(item, shv_dotapp_node_t, shv_node);
+    struct shv_dotapp_node *appnode = UL_CONTAINEROF(item, struct shv_dotapp_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, appnode->version);
     return 0;
 }
 
-int shv_dotapp_node_method_ping(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_ping(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_empty_response(shv_ctx, rid);
     return 0;
 }
 
-int shv_dotapp_node_method_date(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotapp_node_method_date(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_error(shv_ctx, rid, SHV_RE_NOT_IMPLEMENTED, "shv-libs4c missing send date impl");
     return 0;
 }
 
-const shv_method_des_t shv_dmap_item_dotapp_shvversionmajor =
+const struct shv_method_des shv_dmap_item_dotapp_shvversionmajor =
 {
     .name = "shvVersionMajor",
     .flags = SHV_METHOD_GETTER,
@@ -71,7 +71,7 @@ const shv_method_des_t shv_dmap_item_dotapp_shvversionmajor =
     .method = shv_dotapp_node_method_shvversionmajor
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_shvversionminor =
+const struct shv_method_des shv_dmap_item_dotapp_shvversionminor =
 {
     .name = "shvVersionMinor",
     .flags = SHV_METHOD_GETTER,
@@ -80,7 +80,7 @@ const shv_method_des_t shv_dmap_item_dotapp_shvversionminor =
     .method = shv_dotapp_node_method_shvversionminor
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_name =
+const struct shv_method_des shv_dmap_item_dotapp_name =
 {
     .name = "name",
     .flags = SHV_METHOD_GETTER,
@@ -89,7 +89,7 @@ const shv_method_des_t shv_dmap_item_dotapp_name =
     .method = shv_dotapp_node_method_name
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_version =
+const struct shv_method_des shv_dmap_item_dotapp_version =
 {
     .name = "version",
     .flags = SHV_METHOD_GETTER,
@@ -98,7 +98,7 @@ const shv_method_des_t shv_dmap_item_dotapp_version =
     .method = shv_dotapp_node_method_version
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_ping =
+const struct shv_method_des shv_dmap_item_dotapp_ping =
 {
     .name = "ping",
     .flags = 0,
@@ -107,7 +107,7 @@ const shv_method_des_t shv_dmap_item_dotapp_ping =
     .method = shv_dotapp_node_method_ping
 };
 
-const shv_method_des_t shv_dmap_item_dotapp_date =
+const struct shv_method_des shv_dmap_item_dotapp_date =
 {
     .name = "date",
     .flags = 0,
@@ -116,7 +116,7 @@ const shv_method_des_t shv_dmap_item_dotapp_date =
     .method = shv_dotapp_node_method_date
 };
 
-static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
+static const struct shv_method_des *const shv_dmap_dotdevice_items[] =
 {
     &shv_dmap_item_dotapp_date,
     &shv_dmap_item_dir,
@@ -128,12 +128,12 @@ static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
     &shv_dmap_item_dotapp_version
 };
 
-const shv_dmap_t shv_dotapp_dmap =
+const struct shv_dmap shv_dotapp_dmap =
     SHV_CREATE_NODE_DMAP(dotapp, shv_dmap_dotdevice_items);
 
-shv_dotapp_node_t *shv_tree_dotapp_node_new(const shv_dmap_t *dir, int mode)
+struct shv_dotapp_node *shv_tree_dotapp_node_new(const struct shv_dmap *dir, int mode)
 {
-    shv_dotapp_node_t *item = calloc(1, sizeof(shv_dotapp_node_t));
+    struct shv_dotapp_node *item = calloc(1, sizeof(struct shv_dotapp_node));
     if (item == NULL) {
         perror(".app calloc");
         return NULL;

--- a/libs4c/libshvtree/shv_dotdevice_node.c
+++ b/libs4c/libshvtree/shv_dotdevice_node.c
@@ -23,39 +23,39 @@
     #include <nuttx/config.h>
 #endif
 
-static void shv_dotdevice_node_destructor(shv_node_t *node)
+static void shv_dotdevice_node_destructor(struct shv_node *node)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(node, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(node, struct shv_dotdevice_node, shv_node);
     free(devnode);
 }
 
-int shv_dotdevice_node_method_name(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_name(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, devnode->name);
     return 0;
 }
 
-int shv_dotdevice_node_method_version(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_version(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, devnode->version);
     return 0;
 }
 
-int shv_dotdevice_node_method_serial_number(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_serial_number(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_str(shv_ctx, rid, devnode->serial_number);
     return 0;
 }
 
-int shv_dotdevice_node_method_reset(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_reset(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, 0);
     /* Let the response bubble through the network stack */
@@ -69,15 +69,15 @@ int shv_dotdevice_node_method_reset(shv_con_ctx_t *shv_ctx, shv_node_t *item, in
     return -1; /* How the hell did you get here?!! */
 }
 
-int shv_dotdevice_node_method_uptime(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_dotdevice_node_method_uptime(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_dotdevice_node_t *devnode = UL_CONTAINEROF(item, shv_dotdevice_node_t, shv_node);
+    struct shv_dotdevice_node *devnode = UL_CONTAINEROF(item, struct shv_dotdevice_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_int(shv_ctx, rid, devnode->devops.uptime());
     return 0;
 }
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_name =
+const struct shv_method_des shv_dmap_item_dotdevice_node_name =
 {
     .name = "name",
     .flags = SHV_METHOD_GETTER,
@@ -86,7 +86,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_name =
     .method = shv_dotdevice_node_method_name
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_version =
+const struct shv_method_des shv_dmap_item_dotdevice_node_version =
 {
     .name = "version",
     .flags = SHV_METHOD_GETTER,
@@ -95,7 +95,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_version =
     .method = shv_dotdevice_node_method_version
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_serial_number =
+const struct shv_method_des shv_dmap_item_dotdevice_node_serial_number =
 {
     .name = "serialNumber",
     .flags = SHV_METHOD_GETTER,
@@ -104,7 +104,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_serial_number =
     .method = shv_dotdevice_node_method_serial_number
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_uptime =
+const struct shv_method_des shv_dmap_item_dotdevice_node_uptime =
 {
     .name = "uptime",
     .flags = SHV_METHOD_GETTER,
@@ -113,7 +113,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_uptime =
     .method = shv_dotdevice_node_method_uptime
 };
 
-const shv_method_des_t shv_dmap_item_dotdevice_node_reset =
+const struct shv_method_des shv_dmap_item_dotdevice_node_reset =
 {
     .name = "reset",
     .flags = 0,
@@ -122,7 +122,7 @@ const shv_method_des_t shv_dmap_item_dotdevice_node_reset =
     .method = shv_dotdevice_node_method_reset
 };
 
-static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
+static const struct shv_method_des *const shv_dmap_dotdevice_items[] =
 {
     &shv_dmap_item_dir,
     &shv_dmap_item_ls,
@@ -133,12 +133,12 @@ static const shv_method_des_t *const shv_dmap_dotdevice_items[] =
     &shv_dmap_item_dotdevice_node_version
 };
 
-const shv_dmap_t shv_dotdevice_dmap =
+const struct shv_dmap shv_dotdevice_dmap =
     SHV_CREATE_NODE_DMAP(dotdevice, shv_dmap_dotdevice_items);
 
-shv_dotdevice_node_t *shv_tree_dotdevice_node_new(const shv_dmap_t *dir, int mode)
+struct shv_dotdevice_node *shv_tree_dotdevice_node_new(const struct shv_dmap *dir, int mode)
 {
-    shv_dotdevice_node_t *item = calloc(1, sizeof(shv_dotdevice_node_t));
+    struct shv_dotdevice_node *item = calloc(1, sizeof(struct shv_dotdevice_node));
     if (item == NULL) {
         perror(".device calloc");
         return NULL;

--- a/libs4c/libshvtree/shv_file_node.c
+++ b/libs4c/libshvtree/shv_file_node.c
@@ -66,14 +66,14 @@ enum shv_file_node_keys
  *
  * @param node
  */
-static void shv_file_node_destructor(shv_node_t *node)
+static void shv_file_node_destructor(struct shv_node *node)
 {
-  shv_file_node_t *file_node = UL_CONTAINEROF(node, shv_file_node_t, shv_node);
+  struct shv_file_node *file_node = UL_CONTAINEROF(node, struct shv_file_node, shv_node);
   free(file_node->fctx);
   free(&file_node->shv_node);
 }
 
-void shv_file_send_stat(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+void shv_file_send_stat(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -124,7 +124,7 @@ void shv_file_send_stat(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
     }
 }
 
-void shv_file_send_size(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+void shv_file_send_size(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     ccpcp_pack_context_init(&shv_ctx->pack_ctx,shv_ctx->shv_data, SHV_BUF_LEN,
                             shv_overflow_handler);
@@ -148,7 +148,7 @@ void shv_file_send_size(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
     }
 }
 
-int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+int shv_file_process_write(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     int ret;
     ccpcp_unpack_context *ctx = &shv_ctx->unpack_ctx;
@@ -291,7 +291,7 @@ int shv_file_process_write(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *ite
  * If only the first number is passed (offset), CRC is calculated until the end of the file.
  * If both numbers are passed (offset and size), CRC is calcaulted over size bytes.
  */
-int shv_file_process_crc(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
+int shv_file_process_crc(struct shv_con_ctx *shv_ctx, int rid, struct shv_file_node *item)
 {
     int parse_result = -1;
     size_t size;
@@ -419,10 +419,10 @@ int shv_file_process_crc(shv_con_ctx_t *shv_ctx, int rid, shv_file_node_t *item)
     return -1;
 }
 
-int shv_file_node_write(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_write(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     int ret = 0;
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     ret = shv_file_process_write(shv_ctx, rid, file_node);
     if (ret < 0) {
         shv_send_error(shv_ctx, rid, SHV_RE_INVALID_PARAMS, "Garbled data");
@@ -435,10 +435,10 @@ int shv_file_node_write(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
     return 0;
 }
 
-int shv_file_node_crc(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_crc(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
     int ret;
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     ret = shv_file_process_crc(shv_ctx, rid, file_node);
     if (ret < 0) {
         shv_send_error(shv_ctx, rid, SHV_RE_INVALID_PARAMS, "Garbled data");
@@ -451,25 +451,26 @@ int shv_file_node_crc(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
     return ret;
 }
 
-int shv_file_node_size(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_size(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_send_uint(shv_ctx, rid, file_node->file_maxsize);
     return 0;
 }
 
-int shv_file_node_stat(shv_con_ctx_t *shv_ctx, shv_node_t *item, int rid)
+int shv_file_node_stat(struct shv_con_ctx *shv_ctx, struct shv_node *item, int rid)
 {
-    shv_file_node_t *file_node = UL_CONTAINEROF(item, shv_file_node_t, shv_node);
+    struct shv_file_node *file_node = UL_CONTAINEROF(item, struct shv_file_node, shv_node);
     shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
     shv_file_send_stat(shv_ctx, rid, file_node);
     return 0;
 }
 
-shv_file_node_t *shv_tree_file_node_new(const char *child_name, const shv_dmap_t *dir, int mode)
+struct shv_file_node *shv_tree_file_node_new(const char *child_name, const struct shv_dmap *dir,
+                                             int mode)
 {
-    shv_file_node_t *item = calloc(1, sizeof(shv_file_node_t));
+    struct shv_file_node *item = calloc(1, sizeof(struct shv_file_node));
     if (item == NULL) {
         perror("file node calloc");
         return NULL;
@@ -493,31 +494,31 @@ shv_file_node_t *shv_tree_file_node_new(const char *child_name, const shv_dmap_t
     return item;
 }
 
-const shv_method_des_t shv_dmap_item_file_node_crc =
+const struct shv_method_des shv_dmap_item_file_node_crc =
 {
     .name = "crc",
     .method = shv_file_node_crc
 };
 
-const shv_method_des_t shv_dmap_item_file_node_write =
+const struct shv_method_des shv_dmap_item_file_node_write =
 {
     .name = "write",
     .method = shv_file_node_write
 };
 
-const shv_method_des_t shv_dmap_item_file_node_stat =
+const struct shv_method_des shv_dmap_item_file_node_stat =
 {
     .name = "stat",
     .method = shv_file_node_stat
 };
 
-const shv_method_des_t shv_dmap_item_file_node_size =
+const struct shv_method_des shv_dmap_item_file_node_size =
 {
     .name = "size",
     .method = shv_file_node_size
 };
 
-static const shv_method_des_t * const shv_file_node_dmap_items[] =
+static const struct shv_method_des * const shv_file_node_dmap_items[] =
 {
   &shv_dmap_item_file_node_crc,
   &shv_dmap_item_dir,
@@ -527,4 +528,4 @@ static const shv_method_des_t * const shv_file_node_dmap_items[] =
   &shv_dmap_item_file_node_write
 };
 
-const shv_dmap_t shv_file_node_dmap = SHV_CREATE_NODE_DMAP(file_node, shv_file_node_dmap_items);
+const struct shv_dmap shv_file_node_dmap = SHV_CREATE_NODE_DMAP(file_node, shv_file_node_dmap_items);

--- a/libs4c/libshvtree/shv_methods.c
+++ b/libs4c/libshvtree/shv_methods.c
@@ -19,12 +19,12 @@
 
 /* Method descriptors - general methods "ls" and "dir" */
 
-const shv_method_des_t shv_dmap_item_ls = {
+const struct shv_method_des shv_dmap_item_ls = {
   .name = "ls",
   .access = SHV_ACCESS_BROWSE,
   .method = shv_ls
 };
-const shv_method_des_t shv_dmap_item_dir = {
+const struct shv_method_des shv_dmap_item_dir = {
   .name = "dir",
   .access = SHV_ACCESS_BROWSE,
   .method = shv_dir
@@ -32,7 +32,7 @@ const shv_method_des_t shv_dmap_item_dir = {
 
 /* Method descriptors - methods for parameters */
 
-const shv_method_des_t shv_dmap_item_type = {
+const struct shv_method_des shv_dmap_item_type = {
   .name = "typeName",
   .flags = SHV_METHOD_GETTER,
   .result = "s",
@@ -42,14 +42,14 @@ const shv_method_des_t shv_dmap_item_type = {
 
 /* Method descriptors - methods for double values: params and inputs/outputs */
 
-const shv_method_des_t shv_double_dmap_item_get = {
+const struct shv_method_des shv_double_dmap_item_get = {
   .name = "get",
   .flags = SHV_METHOD_GETTER,
   .result = "d",
   .access = SHV_ACCESS_READ,
   .method = shv_double_get
 };
-const shv_method_des_t shv_double_dmap_item_set = {
+const struct shv_method_des shv_double_dmap_item_set = {
   .name = "set",
   .flags = SHV_METHOD_SETTER,
   .param = "d|f",
@@ -57,7 +57,7 @@ const shv_method_des_t shv_double_dmap_item_set = {
   .method = shv_double_set
 };
 
-const shv_method_des_t * const shv_double_dmap_items[] = {
+const struct shv_method_des * const shv_double_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_double_dmap_item_get,
   &shv_dmap_item_ls,
@@ -65,37 +65,37 @@ const shv_method_des_t * const shv_double_dmap_items[] = {
   &shv_dmap_item_type,
 };
 
-const shv_method_des_t * const shv_double_read_only_dmap_items[] = {
+const struct shv_method_des * const shv_double_read_only_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_double_dmap_item_get,
   &shv_dmap_item_ls,
   &shv_dmap_item_type,
 };
 
-const shv_method_des_t * const shv_dir_ls_dmap_items[] = {
+const struct shv_method_des * const shv_dir_ls_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_dmap_item_ls,
 };
 
-const shv_method_des_t * const shv_root_dmap_items[] = {
+const struct shv_method_des * const shv_root_dmap_items[] = {
   &shv_dmap_item_dir,
   &shv_dmap_item_ls,
 };
 
-const shv_dmap_t shv_double_dmap = {.methods = {.items = (void **)shv_double_dmap_items,
+const struct shv_dmap shv_double_dmap = {.methods = {.items = (void **)shv_double_dmap_items,
                                                 .count = sizeof(shv_double_dmap_items)/sizeof(shv_double_dmap_items[0]),
                                                 .alloc_count = 0,
                                                }};
-const shv_dmap_t shv_double_read_only_dmap = {.methods = {.items = (void **)shv_double_read_only_dmap_items,
+const struct shv_dmap shv_double_read_only_dmap = {.methods = {.items = (void **)shv_double_read_only_dmap_items,
                                               .count = sizeof(shv_double_read_only_dmap_items)/sizeof(shv_double_read_only_dmap_items[0]),
                                               .alloc_count = 0,
                                               }};
-const shv_dmap_t shv_dir_ls_dmap = {.methods = {.items = (void **)shv_dir_ls_dmap_items,
+const struct shv_dmap shv_dir_ls_dmap = {.methods = {.items = (void **)shv_dir_ls_dmap_items,
                                                 .count = sizeof(shv_dir_ls_dmap_items)/sizeof(shv_dir_ls_dmap_items[0]),
                                                 .alloc_count = 0,
                                                }};
 
-const shv_dmap_t shv_root_dmap = {.methods = {.items = (void **)shv_root_dmap_items,
+const struct shv_dmap shv_root_dmap = {.methods = {.items = (void **)shv_root_dmap_items,
                                               .count = sizeof(shv_root_dmap_items)/sizeof(shv_root_dmap_items[0]),
                                               .alloc_count = 0,
                                              }};
@@ -108,10 +108,10 @@ const shv_dmap_t shv_root_dmap = {.methods = {.items = (void **)shv_root_dmap_it
  *
  ****************************************************************************/
 
-int shv_ls(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_ls(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   int count;
-  shv_node_list_names_it_t names_it;
+  struct shv_node_list_names_it names_it;
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
 
@@ -138,7 +138,7 @@ int shv_ls(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_dir(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_dir(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   int met_num;
   int i;
@@ -173,13 +173,13 @@ int shv_dir(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_type(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_type(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   const char *str;
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
 
-  shv_node_typed_val_t *item_node = UL_CONTAINEROF(item, shv_node_typed_val_t,
+  struct shv_node_typed_val *item_node = UL_CONTAINEROF(item, struct shv_node_typed_val,
                                                    shv_node);
 
   str = item_node->type_name;
@@ -197,13 +197,13 @@ int shv_type(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_double_set(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_double_set(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   double shv_received;
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, &shv_received);
 
-  shv_node_typed_val_t *item_node = UL_CONTAINEROF(item, shv_node_typed_val_t,
+  struct shv_node_typed_val *item_node = UL_CONTAINEROF(item, struct shv_node_typed_val,
                                                    shv_node);
 
   *(double *)item_node->val_ptr = shv_received;
@@ -222,13 +222,13 @@ int shv_double_set(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
  *
  ****************************************************************************/
 
-int shv_double_get(shv_con_ctx_t * shv_ctx, shv_node_t* item, int rid)
+int shv_double_get(struct shv_con_ctx * shv_ctx, struct shv_node* item, int rid)
 {
   double shv_send;
 
   shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
 
-  shv_node_typed_val_t *item_node = UL_CONTAINEROF(item, shv_node_typed_val_t,
+  struct shv_node_typed_val *item_node = UL_CONTAINEROF(item, struct shv_node_typed_val,
                                                    shv_node);
 
   shv_send = *(double *)item_node->val_ptr;

--- a/libs4c/libshvtree/shv_tree.c
+++ b/libs4c/libshvtree/shv_tree.c
@@ -25,14 +25,14 @@
 
 /* Custom tree implementation */
 
-GAVL_CUST_NODE_INT_IMP(shv_node_list_gavl, shv_node_list_t, shv_node_t,
+GAVL_CUST_NODE_INT_IMP(shv_node_list_gavl, struct shv_node_list, struct shv_node,
                        shv_node_list_key_t, list.gavl.root, gavl_node,
                        name, shv_node_list_comp_func)
-GSA_CUST_IMP(shv_node_list_gsa, shv_node_list_t, shv_node_t,
+GSA_CUST_IMP(shv_node_list_gsa, struct shv_node_list, struct shv_node,
                        shv_node_list_key_t, list.gsa.root,
                        name, shv_node_list_comp_func, 0)
 
-GSA_CUST_IMP(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
+GSA_CUST_IMP(shv_dmap, struct shv_dmap, struct shv_method_des, shv_method_des_key_t,
 	           methods, name, shv_method_des_comp_func, 0)
 
 /**
@@ -40,19 +40,19 @@ GSA_CUST_IMP(shv_dmap, shv_dmap_t, shv_method_des_t, shv_method_des_key_t,
  *
  * @param node
  */
-static void shv_node_destructor(shv_node_t *node)
+static void shv_node_destructor(struct shv_node *node)
 {
   free(node);
 }
 
 /**
- * @brief Destructor for shv_node_typed_val_t
+ * @brief Destructor for struct shv_node_typed_val
  *
  * @param node
  */
-static void shv_typed_val_node_destructor(shv_node_t *node)
+static void shv_typed_val_node_destructor(struct shv_node *node)
 {
-  shv_node_typed_val_t *typed_node = UL_CONTAINEROF(node, shv_node_typed_val_t, shv_node);
+  struct shv_node_typed_val *typed_node = UL_CONTAINEROF(node, struct shv_node_typed_val, shv_node);
   free(typed_node);
 }
 
@@ -64,7 +64,7 @@ static void shv_typed_val_node_destructor(shv_node_t *node)
  *
  ****************************************************************************/
 
-shv_node_t *shv_node_find(shv_node_t *node, const char * path)
+struct shv_node *shv_node_find(struct shv_node *node, const char * path)
 {
   if (strlen(path) == 0)
     {
@@ -112,7 +112,7 @@ shv_node_t *shv_node_find(shv_node_t *node, const char * path)
  *
  ****************************************************************************/
 
-void shv_node_list_it_reset(shv_node_list_it_t *it)
+void shv_node_list_it_reset(struct shv_node_list_it *it)
 {
   if (it->node_list->mode & SHV_NLIST_MODE_GSA)
     {
@@ -132,7 +132,7 @@ void shv_node_list_it_reset(shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-void shv_node_list_it_init(shv_node_list_t *list, shv_node_list_it_t *it)
+void shv_node_list_it_init(struct shv_node_list *list, struct shv_node_list_it *it)
 {
   it->node_list = list;
   shv_node_list_it_reset(it);
@@ -146,9 +146,9 @@ void shv_node_list_it_init(shv_node_list_t *list, shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it)
+struct shv_node *shv_node_list_it_next(struct shv_node_list_it *it)
 {
-  shv_node_t *node;
+  struct shv_node *node;
 
   if (it->node_list->mode & SHV_NLIST_MODE_GSA)
     {
@@ -171,13 +171,13 @@ shv_node_t *shv_node_list_it_next(shv_node_list_it_t *it)
  *
  ****************************************************************************/
 
-static const char *shv_node_list_names_get_next(shv_str_list_it_t *it,
+static const char *shv_node_list_names_get_next(struct shv_str_list_it *it,
                                                 int reset_to_first)
 {
-  shv_node_list_names_it_t *names_it;
-  shv_node_t *node;
+  struct shv_node_list_names_it *names_it;
+  struct shv_node *node;
 
-  names_it = UL_CONTAINEROF(it, shv_node_list_names_it_t, str_it);
+  names_it = UL_CONTAINEROF(it, struct shv_node_list_names_it, str_it);
 
   if (reset_to_first)
     {
@@ -204,8 +204,8 @@ static const char *shv_node_list_names_get_next(shv_str_list_it_t *it,
  *
  ****************************************************************************/
 
-void shv_node_list_names_it_init(shv_node_list_t *list,
-                                 shv_node_list_names_it_t *names_it)
+void shv_node_list_names_it_init(struct shv_node_list *list,
+                                 struct shv_node_list_names_it *names_it)
 {
   shv_node_list_it_init(list, &names_it->list_it);
   names_it->str_it.get_next_entry = shv_node_list_names_get_next;
@@ -219,7 +219,7 @@ void shv_node_list_names_it_init(shv_node_list_t *list,
  *
  ****************************************************************************/
 
-void shv_tree_add_child(shv_node_t *node, shv_node_t *child)
+void shv_tree_add_child(struct shv_node *node, struct shv_node *child)
 {
   if (node->children.mode & SHV_NLIST_MODE_GSA)
     {
@@ -237,15 +237,15 @@ void shv_tree_add_child(shv_node_t *node, shv_node_t *child)
  * Name: shv_tree_node_init
  *
  * Description:
- *   Initialize the shv_node_t node.
+ *   Initialize the struct shv_node node.
  *
  ****************************************************************************/
 
-void shv_tree_node_init(shv_node_t *item, const char *child_name,
-                        const shv_dmap_t *dir, int mode)
+void shv_tree_node_init(struct shv_node *item, const char *child_name,
+                        const struct shv_dmap *dir, int mode)
 {
   item->name = child_name;
-  item->dir = UL_CAST_UNQ1(shv_dmap_t *, dir);
+  item->dir = UL_CAST_UNQ1(struct shv_dmap *, dir);
 
   item->children.mode = mode;
 
@@ -260,10 +260,10 @@ void shv_tree_node_init(shv_node_t *item, const char *child_name,
     }
 }
 
-shv_node_t *shv_tree_node_new(const char *child_name,
-                              const shv_dmap_t *dir, int mode)
+struct shv_node *shv_tree_node_new(const char *child_name,
+                              const struct shv_dmap *dir, int mode)
 {
-    shv_node_t *item = calloc(1, sizeof(shv_node_t));
+    struct shv_node *item = calloc(1, sizeof(struct shv_node));
     if (item == NULL) {
         perror("node calloc");
         return NULL;
@@ -273,11 +273,11 @@ shv_node_t *shv_tree_node_new(const char *child_name,
     return item;
 }
 
-shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name,
-                                                  const shv_dmap_t *dir,
+struct shv_node_typed_val *shv_tree_node_typed_val_new(const char *child_name,
+                                                  const struct shv_dmap *dir,
                                                   int mode)
 {
-    shv_node_typed_val_t *item = calloc(1, sizeof(shv_node_typed_val_t));
+    struct shv_node_typed_val *item = calloc(1, sizeof(struct shv_node_typed_val));
     if (item == NULL) {
         printf("typed_val node calloc");
         return NULL;
@@ -295,9 +295,9 @@ shv_node_typed_val_t *shv_tree_node_typed_val_new(const char *child_name,
  *
  ****************************************************************************/
 
-void shv_tree_destroy(shv_node_t *parent)
+void shv_tree_destroy(struct shv_node *parent)
 {
-    shv_node_t *child;
+    struct shv_node *child;
 
     if (parent->children.mode & SHV_NLIST_MODE_GSA) {
         gsa_cust_for_each_cut(shv_node_list_gsa, &parent->children, child) {
@@ -323,14 +323,14 @@ void shv_tree_destroy(shv_node_t *parent)
  *
  ****************************************************************************/
 
-int shv_node_process(shv_con_ctx_t *shv_ctx, int rid, const char *met,
+int shv_node_process(struct shv_con_ctx *shv_ctx, int rid, const char *met,
                      const char *path)
 {
     /* If the node or method names are too long, the printed lengths is limited */
     char error_msg[80];
 
     /* Find the node */
-    shv_node_t *item = shv_node_find(shv_ctx->root, path);
+    struct shv_node *item = shv_node_find(shv_ctx->root, path);
     if (item == NULL) {
         shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
         snprintf(error_msg, sizeof(error_msg), "Node '%.40s' does not exist.", path);
@@ -339,7 +339,7 @@ int shv_node_process(shv_con_ctx_t *shv_ctx, int rid, const char *met,
     }
 
     /* Call coresponding method */
-    const shv_method_des_t *met_des = shv_dmap_find(item->dir, &met);
+    const struct shv_method_des *met_des = shv_dmap_find(item->dir, &met);
     if (met_des == NULL) {
         shv_unpack_data(&shv_ctx->unpack_ctx, 0, 0);
         snprintf(error_msg, sizeof(error_msg), "Method '%.40s' does not exist.", met);


### PR DESCRIPTION
This brings a little bit more safety in case enum `shv_con_errno` is changed and `shv_con_errno_strs` is forgotten to change as well.